### PR TITLE
Flatten registered symbols

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,8 @@
                  [com.taoensso/encore "3.24.0"]
                  [com.taoensso/timbre "5.2.1"]
                  [com.taoensso/nippy "3.2.0"]
-                 [funcool/promesa "8.0.450"]]
+                 [funcool/promesa "8.0.450"]
+                 [medley "1.4.0"]]
   :repl-options {:init-ns user}
   :java-source-paths ["src"]
   :javac-options ["-target" "11" "-source" "11"]

--- a/src/temporal/activity.clj
+++ b/src/temporal/activity.clj
@@ -92,9 +92,10 @@ Arguments:
 ```
 "
   [name params* & body]
-  (let [class-name (u/get-classname name)]
-    `(def ~name ^{::a/def ~class-name}
+  (let [fqn (u/get-fq-classname name)
+        sname (str name)]
+    `(def ~name ^{::a/def {:name ~sname :fqn ~fqn}}
        (fn [ctx# args#]
-         (log/trace (str ~class-name ": ") args#)
+         (log/trace (str ~fqn ": ") args#)
          (let [f# (fn ~params* (do ~@body))]
            (f# ctx# args#))))))

--- a/src/temporal/client/core.clj
+++ b/src/temporal/client/core.clj
@@ -96,7 +96,7 @@ Create a new workflow-stub instance, suitable for managing and interacting with 
 ```
 "
   [^WorkflowClient client workflow options]
-  (let [wf-name (w/get-annotation workflow)
+  (let [wf-name (w/get-annotated-name workflow)
         stub    (.newUntypedWorkflowStub client wf-name (w/wf-options-> options))]
     (log/trace "create-workflow:" wf-name options)
     {:client client :stub stub}))

--- a/src/temporal/internal/activity.clj
+++ b/src/temporal/internal/activity.clj
@@ -47,7 +47,7 @@
 
 (defn get-annotation
   ^String [x]
-  (u/get-annotation x ::def))
+  (u/get-annotated-name x ::def))
 
 (defn- export-result [activity-id x]
   (log/trace activity-id "result:" x)

--- a/src/temporal/internal/workflow.clj
+++ b/src/temporal/internal/workflow.clj
@@ -37,9 +37,9 @@
 (defn get-info []
   (d/datafy (Workflow/getInfo)))
 
-(defn get-annotation
+(defn get-annotated-name
   ^String [x]
-  (u/get-annotation x ::def))
+  (u/get-annotated-name x ::def))
 
 (defn execute
   [ctx args]

--- a/src/temporal/workflow.clj
+++ b/src/temporal/workflow.clj
@@ -35,9 +35,10 @@ Arguments:
 ```
 "
   [name params* & body]
-  (let [class-name (u/get-classname name)]
-    `(def ~name ^{::w/def ~class-name}
+  (let [fqn (u/get-fq-classname name)
+        sname (str name)]
+    `(def ~name ^{::w/def {:name ~sname :fqn ~fqn}}
        (fn [ctx# args#]
-         (log/trace (str ~class-name ": ") args#)
+         (log/trace (str ~fqn ": ") args#)
          (let [f# (fn ~params* (do ~@body))]
            (f# ctx# args#))))))

--- a/test/temporal/test/async.clj
+++ b/test/temporal/test/async.clj
@@ -11,7 +11,7 @@
 
 (use-fixtures :once t/wrap-service)
 
-(defactivity greet-activity
+(defactivity async-greet-activity
   [ctx {:keys [name] :as args}]
   (go
     (log/info "greet-activity:" args)
@@ -19,18 +19,18 @@
       (ex-info "permission-denied" {})                      ;; we don't like Charlie
       (str "Hi, " name))))
 
-(defworkflow greeter-workflow
+(defworkflow async-greeter-workflow
   [ctx {:keys [args]}]
   (log/info "greeter-workflow:" args)
-  @(a/invoke greet-activity args (assoc a/default-invoke-options :retry-options {:maximum-attempts 1})))
+  @(a/invoke async-greet-activity args (assoc a/default-invoke-options :retry-options {:maximum-attempts 1})))
 
 (deftest the-test
   (testing "Verifies that we can round-trip with an async task"
-    (let [workflow (t/create-workflow greeter-workflow)]
+    (let [workflow (t/create-workflow async-greeter-workflow)]
       (c/start workflow {:name "Bob"})
       (is (= @(c/get-result workflow) "Hi, Bob"))))
   (testing "Verifies that we can process errors in async mode"
-    (let [workflow (t/create-workflow greeter-workflow)]
+    (let [workflow (t/create-workflow async-greeter-workflow)]
       (c/start workflow {:name "Charlie"})
       (is (thrown? java.util.concurrent.ExecutionException
                    @(c/get-result workflow))))))

--- a/test/temporal/test/client_signal.clj
+++ b/test/temporal/test/client_signal.clj
@@ -16,7 +16,7 @@
   (lazy-seq (when-let [m (<! signals signal-name)]
               (cons m (lazy-signals signals)))))
 
-(defworkflow test-workflow
+(defworkflow client-signal-workflow
   [ctx {:keys [signals] {:keys [nr] :as args} :args}]
   (log/info "test-workflow:" args)
   (doall (take nr (lazy-signals signals))))
@@ -25,7 +25,7 @@
 
 (deftest the-test
   (testing "Verifies that we can send signals from a client"
-    (let [workflow (t/create-workflow test-workflow)]
+    (let [workflow (t/create-workflow client-signal-workflow)]
       (c/start workflow {:nr expected})
       (dotimes [n expected]
         (>! workflow signal-name n))

--- a/test/temporal/test/concurrency.clj
+++ b/test/temporal/test/concurrency.clj
@@ -12,13 +12,13 @@
 
 (use-fixtures :once t/wrap-service)
 
-(defactivity echo-activity
+(defactivity concurrency-activity
   [ctx args]
   (log/info "activity:" args)
   args)
 
 (defn invoke [x]
-  (a/invoke echo-activity x))
+  (a/invoke concurrency-activity x))
 
 (defworkflow concurrency-workflow
   [ctx {:keys [args]}]

--- a/test/temporal/test/conflict.clj
+++ b/test/temporal/test/conflict.clj
@@ -1,0 +1,13 @@
+;; Copyright © 2022 Manetu, Inc.  All rights reserved
+
+(ns temporal.test.conflict
+  (:require [clojure.test :refer :all]
+            [temporal.internal.utils :as u]
+            [temporal.test.utils :as t]))
+
+(use-fixtures :once t/wrap-service)
+
+(deftest conflict-detect-test
+  (testing "Verify that we detect symbol conflicts"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (u/verify-registered-fns [{:name "foo" :fqn "bar.foo"} {:name "foo" :fqn "baz.foo"}])))))

--- a/test/temporal/test/local_activity.clj
+++ b/test/temporal/test/local_activity.clj
@@ -10,18 +10,18 @@
 
 (use-fixtures :once t/wrap-service)
 
-(defactivity greet-activity
+(defactivity local-greet-activity
   [ctx {:keys [name] :as args}]
   (log/info "greet-activity:" args)
   (str "Hi, " name))
 
-(defworkflow greeter-workflow
+(defworkflow local-greeter-workflow
   [ctx {:keys [args]}]
   (log/info "greeter-workflow:" args)
-  @(a/local-invoke greet-activity args (assoc a/default-invoke-options :do-not-include-args true)))
+  @(a/local-invoke local-greet-activity args (assoc a/default-invoke-options :do-not-include-args true)))
 
 (deftest the-test
   (testing "Verifies that we can round-trip through start"
-    (let [workflow (t/create-workflow greeter-workflow)]
+    (let [workflow (t/create-workflow local-greeter-workflow)]
       (c/start workflow {:name "Bob"})
       (is (= @(c/get-result workflow) "Hi, Bob")))))

--- a/test/temporal/test/poll.clj
+++ b/test/temporal/test/poll.clj
@@ -16,17 +16,17 @@
   (lazy-seq (when-let [m (s/poll signals signal-name)]
               (cons m (lazy-signals signals)))))
 
-(defworkflow test-workflow
+(defworkflow poll-workflow
   [ctx {:keys [signals]}]
   (log/info "test-workflow:")
   (doall (lazy-signals signals)))
 
 (deftest the-test
   (testing "Verifies that poll exits with nil when there are no signals"
-    (let [workflow (t/create-workflow test-workflow)]
+    (let [workflow (t/create-workflow poll-workflow)]
       (c/start workflow {})
       (is (-> workflow c/get-result deref count (= 0)))))
   (testing "Verifies that we receive signals with poll correctly"
-    (let [workflow (t/create-workflow test-workflow)]
+    (let [workflow (t/create-workflow poll-workflow)]
       (c/signal-with-start workflow signal-name {:foo "bar"} {})
       (is (-> workflow c/get-result deref first (get :foo) (= "bar"))))))

--- a/test/temporal/test/race.clj
+++ b/test/temporal/test/race.clj
@@ -12,7 +12,7 @@
 
 (use-fixtures :once t/wrap-service)
 
-(defactivity delayed-activity
+(defactivity race-activity
   [ctx {:keys [id delay] :as args}]
   (log/info "activity:" args)
   (go
@@ -20,7 +20,7 @@
     id))
 
 (defn invoke [x]
-  (a/invoke delayed-activity x))
+  (a/invoke race-activity x))
 
 (defworkflow race-workflow
   [ctx {:keys [args]}]

--- a/test/temporal/test/scale.clj
+++ b/test/temporal/test/scale.clj
@@ -12,20 +12,20 @@
 
 (use-fixtures :once t/wrap-service)
 
-(defactivity echo-activity
+(defactivity scale-activity
   [ctx {:keys [id] :as args}]
   (log/info "activity:" args)
   (go
     (<! (async/timeout 1000))
     id))
 
-(defworkflow parallel-workflow
+(defworkflow scale-workflow
   [ctx {:keys [args]}]
   (log/info "workflow:" args)
-  @(a/invoke echo-activity args))
+  @(a/invoke scale-activity args))
 
 (defn create [id]
-  (let [workflow (t/create-workflow parallel-workflow)]
+  (let [workflow (t/create-workflow scale-workflow)]
     (c/start workflow {:id id})
     (c/get-result workflow)))
 

--- a/test/temporal/test/sequence.clj
+++ b/test/temporal/test/sequence.clj
@@ -12,7 +12,7 @@
 
 (use-fixtures :once t/wrap-service)
 
-(defactivity greet-activity
+(defactivity sequence-activity
   [ctx args]
   (log/info "greet-activity:" args)
   (str "Hi, " args))
@@ -21,9 +21,9 @@
   [ctx _]
   @(-> (pt/resolved true)
        (p/then (fn [_]
-                 (a/invoke greet-activity "Bob")))
+                 (a/invoke sequence-activity "Bob")))
        (p/then (fn [_]
-                 (a/invoke greet-activity "Charlie")))
+                 (a/invoke sequence-activity "Charlie")))
        (p/then (constantly :ok))))
 
 (deftest the-test

--- a/test/temporal/test/signal_with_start.clj
+++ b/test/temporal/test/signal_with_start.clj
@@ -13,19 +13,19 @@
 
 (def signal-name ::signal)
 
-(defactivity greet-activity
+(defactivity signal-greet-activity
   [ctx {:keys [greeting name] :as args}]
   (log/info "greet-activity:" args)
   (str greeting ", " name))
 
-(defworkflow greeter-workflow
+(defworkflow signal-greeter-workflow
   [ctx {:keys [args signals]}]
   (log/info "greeter-workflow:" args)
   (let [m (<! signals signal-name)]
-    @(a/invoke greet-activity (merge args m))))
+    @(a/invoke signal-greet-activity (merge args m))))
 
 (deftest the-test
   (testing "Verifies that we can round-trip through signal-with-start"
-    (let [workflow (t/create-workflow greeter-workflow)]
+    (let [workflow (t/create-workflow signal-greeter-workflow)]
       (c/signal-with-start workflow signal-name {:name "Bob"} {:greeting "Hi"})
       (is (= @(c/get-result workflow) "Hi, Bob")))))

--- a/test/temporal/test/simple.clj
+++ b/test/temporal/test/simple.clj
@@ -10,18 +10,18 @@
 
 (use-fixtures :once t/wrap-service)
 
-(defactivity greet-activity
+(defactivity simple-greet-activity
   [ctx {:keys [name] :as args}]
   (log/info "greet-activity:" args)
   (str "Hi, " name))
 
-(defworkflow greeter-workflow
+(defworkflow simple-greeter-workflow
   [ctx {:keys [args]}]
   (log/info "greeter-workflow:" args)
-  @(a/invoke greet-activity args (assoc a/default-invoke-options :retry-options {:maximum-attempts 1})))
+  @(a/invoke simple-greet-activity args (assoc a/default-invoke-options :retry-options {:maximum-attempts 1})))
 
 (deftest the-test
   (testing "Verifies that we can round-trip through start"
-    (let [workflow (t/create-workflow greeter-workflow)]
+    (let [workflow (t/create-workflow simple-greeter-workflow)]
       (c/start workflow {:name "Bob"})
       (is (= @(c/get-result workflow) "Hi, Bob")))))

--- a/test/temporal/test/uuid_test.clj
+++ b/test/temporal/test/uuid_test.clj
@@ -10,14 +10,14 @@
 
 (use-fixtures :once t/wrap-service)
 
-(defworkflow test-workflow
+(defworkflow uuid-workflow
   [ctx args]
-  (log/info "the-workflow:" args)
+  (log/info "workflow:" args)
   (core/gen-uuid))
 
 (deftest the-test
   (testing "Verifies that we can use the side-effect safe gen-uuid"
-    (let [workflow (t/create-workflow test-workflow)]
+    (let [workflow (t/create-workflow uuid-workflow)]
       (c/start workflow {})
       (let [r  @(c/get-result workflow)]
         (log/debug "r:" r)

--- a/test/temporal/test/workflow_signal.clj
+++ b/test/temporal/test/workflow_signal.clj
@@ -12,20 +12,20 @@
 
 (def signal-name ::signal)
 
-(defworkflow primary-workflow
+(defworkflow wfsignal-primary-workflow
   [ctx {:keys [signals] :as args}]
   (log/info "primary-workflow:" args)
   (<! signals signal-name))
 
-(defworkflow secondary-workflow
+(defworkflow wfsignal-secondary-workflow
   [ctx {{:keys [workflow-id msg]} :args}]
   (log/info "secondary-workflow:" msg)
   (>! workflow-id signal-name msg))
 
 (deftest the-test
   (testing "Verifies that we can send signals from a workflow"
-    (let [p-wf (c/create-workflow (t/get-client) primary-workflow {:task-queue t/task-queue :workflow-id "primary"})
-          s-wf (t/create-workflow secondary-workflow)]
+    (let [p-wf (c/create-workflow (t/get-client) wfsignal-primary-workflow {:task-queue t/task-queue :workflow-id "primary"})
+          s-wf (t/create-workflow wfsignal-secondary-workflow)]
       (c/start p-wf nil)
       (c/start s-wf {:workflow-id "primary" :msg "Hi, Bob"})
       (is (= @(c/get-result p-wf) "Hi, Bob")))))


### PR DESCRIPTION
N.B.  This patch changes the contract between workflows and is thus a breaking change

The current code registers each defworkflow/defactivity with a fully qualified name, and this becomes part of the Temporal contract.  However, Temporal already guarantees uniquness on a per namespace+taskqueue basis.  Therefore, having the workflow/activity also be fully qualified introduces an extra degree of fragility, because simply refactoring clojure namespaces changes the contract.

Other SDKs like Golang use the workflow/activity function name (alone, without the package prefix) as the contract, so this brings the Clojure SDK in line with prior practices and elimintes a source of fragility at the expense of requiring the program to uniquely name symbols even across namespaces.

Signed-off-by: Greg Haskins <greg@manetu.com>