### PR TITLE
Do not memoize fn annotations

### DIFF
--- a/src/temporal/internal/utils.clj
+++ b/src/temporal/internal/utils.clj
@@ -69,12 +69,11 @@
                       (vals))]
         (throw (ex-info "conflict detected: All temporal workflows and activities must be uniquely named" {:conflicts data}))))))
 
-(def get-annotated-fns
-  (memoize
-   (fn [marker]
-     (let [data (find-annotated-fns marker)]
-       (verify-registered-fns data)
-       (m/index-by :name data)))))
+(defn get-annotated-fns
+  [marker]
+  (let [data (find-annotated-fns marker)]
+    (verify-registered-fns data)
+    (m/index-by :name data)))
 
 (defn find-dispatch-fn
   "Finds any functions named 't' that carry metadata 'marker'"


### PR DESCRIPTION
They are only read at worker-init, and in doing so we make develpment more awkward because REPL refreshes do not pick up code updates.

Signed-off-by: Greg Haskins <greg@manetu.com>