### PR TITLE
Refactor the temporal.testing.env

### DIFF
--- a/doc/testing.md
+++ b/doc/testing.md
@@ -31,12 +31,16 @@ You can use the provided environment with a Clojure unit testing framework of yo
 
 (deftest my-test
   (testing "Verifies that we can invoke our greeter workflow"
-    (let [{:keys [client] :as env} (e/create {:task-queue task-queue})
-          (c/create-workflow client greeter-workflow {:task-queue task-queue})]
-      (c/start workflow {:name "Bob"})
+    (let [env    (e/create)
+          client (e/get-client env)]
+      (e/start env {:task-queue task-queue})
+      (let [workflow (c/create-workflow client greeter-workflow {:task-queue task-queue})]
+        (c/start workflow {:name "Bob"}))
       (is (= @(c/get-result workflow) "Hi, Bob")))))
 ```
 
-The primary difference between this test and a real-world application is the use of [temporal.testing.env/create](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.testing.env#create) function.  This method simultaneously creates an instance of the in-memory Temporal service *and* a client already connected to this environment.
+The primary difference between this test and a real-world application is the use of [temporal.testing.env/create](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.testing.env#create) function.  The features in the temporal.testing.env namespace allow you to create an instance of an in-memory Temporal service along with an associated Temporal worker and client connected to this instance.
 
-Typical tests may opt to create the testing environment within a [fixture](https://clojuredocs.org/clojure.test/use-fixtures), but this is left as an exercise to the reader.  The testing environment may be cleanly shutdown with [temporal.testing.env/stop](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.testing.env#stop).
+Typical tests may opt to create the testing environment within a [fixture](https://clojuredocs.org/clojure.test/use-fixtures), but this is left as an exercise to the reader.
+
+The testing environment may be cleanly shutdown with [temporal.testing.env/stop](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.testing.env#stop).

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.manetu/temporal-sdk "0.10.5-SNAPSHOT"
+(defproject io.github.manetu/temporal-sdk "0.11.0-SNAPSHOT"
   :description "A Temporal SDK for Clojure"
   :url "https://github.com/manetu/temporal-clojure-sdk"
   :license {:name "Apache License 2.0"

--- a/test/temporal/test/manual_dispatch.clj
+++ b/test/temporal/test/manual_dispatch.clj
@@ -49,8 +49,10 @@
 ;; Fixtures
 ;;-----------------------------------------------------------------------------
 (defn create-service []
-  (let [{:keys [client] :as env} (e/create {:task-queue task-queue
-                                            :dispatch {:workflows [explicitly-registered-workflow]}})] ;; note that we intentionally omit explicitly-skipped-workflow
+  (let [env    (e/create)
+        client (e/get-client env)]
+    (e/start env {:task-queue task-queue
+                  :dispatch {:workflows [explicitly-registered-workflow]}}) ;; note that we intentionally omit explicitly-skipped-workflow
     (swap! state assoc
            :env env
            :client client)))

--- a/test/temporal/test/utils.clj
+++ b/test/temporal/test/utils.clj
@@ -29,7 +29,9 @@
 ;; Fixtures
 ;;-----------------------------------------------------------------------------
 (defn create-service []
-  (let [{:keys [client] :as env} (e/create {:task-queue task-queue})]
+  (let [env    (e/create)
+        client (e/get-client env)]
+    (e/start env {:task-queue task-queue})
     (swap! state assoc
            :env env
            :client client)))


### PR DESCRIPTION
N.B. This is a breaking change for the temporal.testing.env namespace.

There are use cases where we need to pass a temporal client in the :ctx, but this was impossible with the current "all in one" design of temporal.testing.env/create.

Therefore, we split this up into three distinct operations: create/start/get-client.  This now means that we get a chance to call create/get-client before invoking start, yielding the opportunity to build the worker :ctx as we require.

Signed-off-by: Greg Haskins <greg@manetu.com>