### PR TITLE
document default start-to-close-timeout

### DIFF
--- a/src/temporal/activity.clj
+++ b/src/temporal/activity.clj
@@ -35,7 +35,7 @@ Arguments:
 | :cancellation-type         | Defines the activity's stub cancellation mode.                                             | See `cancellation types` below | :try-cancel |
 | :heartbeat-timeout         | Heartbeat interval.                                                                        | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | |
 | :retry-options             | Define how activity is retried in case of failure.                                         | [[temporal.common/retry-options]] | |
-| :start-to-close-timeout    | Maximum time of a single Activity execution attempt.                                       | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | |
+| :start-to-close-timeout    | Maximum time of a single Activity execution attempt.                                       | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | 3 seconds |
 | :schedule-to-close-timeout | Total time that a workflow is willing to wait for Activity to complete.                    | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | |
 | :schedule-to-start-timeout | Time that the Activity Task can stay in the Task Queue before it is picked up by a Worker. | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | |
 


### PR DESCRIPTION
Found out this is set to 3 seconds here: https://github.com/manetu/temporal-clojure-sdk/blob/a982c2d3d0161225998f32211f2d5c67b7419984/src/temporal/internal/activity.clj#L34

FWIW, I think default timeouts are a great idea but feel it's better for a wrapper to be thin than proper.