### PR TITLE
Add register-signal-handler! and signal-channel abstraction

### DIFF
--- a/doc/clients.md
+++ b/doc/clients.md
@@ -33,7 +33,7 @@ As a simple example, for the following Workflow implementation:
   (str "Hi, " name))
 
 (defworkflow greeter-workflow
-  [ctx {:keys [args]}]
+  [args]
   (log/info "greeter-workflow:" args)
   @(a/invoke greet-activity args))
 ```

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -25,7 +25,7 @@ You can use the provided environment with a Clojure unit testing framework of yo
   (str "Hi, " name))
 
 (defworkflow greeter-workflow
-  [ctx {:keys [args]}]
+  [args]
   (log/info "greeter-workflow:" args)
   @(a/invoke greet-activity args))
 

--- a/doc/workers.md
+++ b/doc/workers.md
@@ -25,7 +25,7 @@ As a simple example, let's say we want our Worker to be able to execute the foll
   (str "Hi, " name))
 
 (defworkflow greeter-workflow
-  [ctx {:keys [args]}]
+  [args]
   (log/info "greeter-workflow:" args)
   @(a/invoke greet-activity args))
 ```

--- a/src/temporal/internal/signals.clj
+++ b/src/temporal/internal/signals.clj
@@ -21,13 +21,16 @@
              (.add ch payload)
              (assoc s signal-name ch)))))
 
-(defn create
-  "Registers the calling workflow to receive signals and returns a context variable to be passed back later"
+(defn register-signal-handler!
+  [f]
+  (Workflow/registerListener
+   (reify
+     DynamicSignalHandler
+     (handle [_ signal-name args]
+       (f signal-name (u/->args args))))))
+
+(defn create-signal-chan
   []
   (let [state (atom {})]
-    (Workflow/registerListener
-     (reify
-       DynamicSignalHandler
-       (handle [_ signal-name args]
-         (-handle state signal-name (u/->args args)))))
+    (register-signal-handler! (partial -handle state))
     state))

--- a/src/temporal/internal/utils.clj
+++ b/src/temporal/internal/utils.clj
@@ -75,11 +75,16 @@
     (verify-registered-fns data)
     (m/index-by :name data)))
 
+(defn find-dispatch
+  "Finds any dispatch descriptor named 't' that carry metadata 'marker'"
+  [dispatch-table t]
+  (or (get dispatch-table t)
+      (throw (ex-info "workflow/activity not found" {:function t}))))
+
 (defn find-dispatch-fn
   "Finds any functions named 't' that carry metadata 'marker'"
   [dispatch-table t]
-  (:fn (or (get dispatch-table t)
-           (throw (ex-info "workflow/activity not found" {:function t})))))
+  (:fn (find-dispatch dispatch-table t)))
 
 (defn import-dispatch
   [marker coll]

--- a/src/temporal/internal/workflow.clj
+++ b/src/temporal/internal/workflow.clj
@@ -53,10 +53,13 @@
   [ctx dispatch args]
   (try
     (let [{:keys [workflow-type workflow-id]} (get-info)
-          f (u/find-dispatch-fn dispatch workflow-type)
+          d (u/find-dispatch dispatch workflow-type)
+          f (:fn d)
           a (u/->args args)
           _ (log/trace workflow-id "calling" f "with args:" a)
-          r (f ctx {:args a :signals (s/create)})]
+          r (if (-> d :type (= :legacy))
+              (f ctx {:args a :signals (s/create-signal-chan)})
+              (f a))]
       (log/trace workflow-id "result:" r)
       (nippy/freeze r))
     (catch Exception e

--- a/test/temporal/test/async.clj
+++ b/test/temporal/test/async.clj
@@ -20,7 +20,7 @@
       (str "Hi, " name))))
 
 (defworkflow async-greeter-workflow
-  [ctx {:keys [args]}]
+  [args]
   (log/info "greeter-workflow:" args)
   @(a/invoke async-greet-activity args {:retry-options {:maximum-attempts 1}}))
 

--- a/test/temporal/test/client_signal.clj
+++ b/test/temporal/test/client_signal.clj
@@ -4,7 +4,7 @@
   (:require [clojure.test :refer :all]
             [taoensso.timbre :as log]
             [temporal.client.core :refer [>!] :as c]
-            [temporal.signals :refer [<!]]
+            [temporal.signals :refer [<!] :as s]
             [temporal.workflow :refer [defworkflow]]
             [temporal.test.utils :as t]))
 
@@ -17,9 +17,10 @@
               (cons m (lazy-signals signals)))))
 
 (defworkflow client-signal-workflow
-  [ctx {:keys [signals] {:keys [nr] :as args} :args}]
+  [{:keys [nr] :as args}]
   (log/info "test-workflow:" args)
-  (doall (take nr (lazy-signals signals))))
+  (let [signals (s/create-signal-chan)]
+    (doall (take nr (lazy-signals signals)))))
 
 (def expected 3)
 

--- a/test/temporal/test/concurrency.clj
+++ b/test/temporal/test/concurrency.clj
@@ -21,7 +21,7 @@
   (a/invoke concurrency-activity x))
 
 (defworkflow concurrency-workflow
-  [ctx {:keys [args]}]
+  [args]
   (log/info "workflow:" args)
   @(-> (pt/all (map invoke (range 10)))
        (p/then (fn [r]

--- a/test/temporal/test/heartbeat.clj
+++ b/test/temporal/test/heartbeat.clj
@@ -18,7 +18,7 @@
       (throw (ex-info "heartbeat details not found" {})))))
 
 (defworkflow heartbeat-workflow
-  [_ _]
+  [_]
   @(a/invoke heartbeat-activity {}))
 
 (deftest the-test

--- a/test/temporal/test/legacy_workflow.clj
+++ b/test/temporal/test/legacy_workflow.clj
@@ -1,0 +1,25 @@
+;; Copyright © Manetu, Inc.  All rights reserved
+
+(ns temporal.test.legacy-workflow
+  (:require [clojure.test :refer :all]
+            [taoensso.timbre :as log]
+            [temporal.client.core :refer [>!] :as c]
+            [temporal.signals :refer [<!] :as s]
+            [temporal.workflow :refer [defworkflow]]
+            [temporal.test.utils :as t]))
+
+(use-fixtures :once t/wrap-service)
+
+(def signal-name ::signal)
+
+(defworkflow legacy-workflow
+  [_ {:keys [signals args]}]
+  (log/info "legacy-workflow:" args)
+  (<! signals signal-name))
+
+(deftest the-test
+  (testing "Verifies that we support a legacy workflow with [ctx {:keys [signals]}"
+    (let [workflow (t/create-workflow legacy-workflow)]
+      (c/start workflow {})
+      (>! workflow signal-name :foo)
+      (is (-> workflow c/get-result deref (= :foo))))))

--- a/test/temporal/test/local_activity.clj
+++ b/test/temporal/test/local_activity.clj
@@ -16,7 +16,7 @@
   (str "Hi, " name))
 
 (defworkflow local-greeter-workflow
-  [ctx {:keys [args]}]
+  [args]
   (log/info "greeter-workflow:" args)
   @(a/local-invoke local-greet-activity args {:do-not-include-args true}))
 

--- a/test/temporal/test/manual_dispatch.clj
+++ b/test/temporal/test/manual_dispatch.clj
@@ -36,12 +36,12 @@
 ;;-----------------------------------------------------------------------------
 
 (defworkflow explicitly-registered-workflow
-  [ctx {:keys [args]}]
+  [args]
   (log/info "registered-workflow:" args)
   :ok)
 
 (defworkflow explicitly-skipped-workflow
-  [ctx {:keys [args]}]
+  [args]
   (log/info "skipped-workflow:" args)
   :ok)
 

--- a/test/temporal/test/poll.clj
+++ b/test/temporal/test/poll.clj
@@ -17,9 +17,9 @@
               (cons m (lazy-signals signals)))))
 
 (defworkflow poll-workflow
-  [ctx {:keys [signals]}]
+  [_]
   (log/info "test-workflow:")
-  (doall (lazy-signals signals)))
+  (doall (lazy-signals (s/create-signal-chan))))
 
 (deftest the-test
   (testing "Verifies that poll exits with nil when there are no signals"

--- a/test/temporal/test/query.clj
+++ b/test/temporal/test/query.clj
@@ -2,9 +2,8 @@
 
 (ns temporal.test.query
   (:require [clojure.test :refer :all]
-            [taoensso.timbre :as log]
             [temporal.client.core :refer [>!] :as c]
-            [temporal.signals :refer [<!]]
+            [temporal.signals :refer [<!] :as s]
             [temporal.workflow :as w]
             [temporal.workflow :refer [defworkflow]]
             [temporal.test.utils :as t]))
@@ -15,8 +14,9 @@
 (def query-name ::query)
 
 (defworkflow state-query-workflow
-  [ctx {:keys [signals] {:keys [] :as args} :args}]
-  (let [state (atom 0)]
+  [args]
+  (let [state (atom 0)
+        signals (s/create-signal-chan)]
     (w/register-query-handler! (fn [query-type args]
                                  @state))
     (dotimes [n 3]

--- a/test/temporal/test/race.clj
+++ b/test/temporal/test/race.clj
@@ -23,7 +23,7 @@
   (a/invoke race-activity x))
 
 (defworkflow race-workflow
-  [ctx {:keys [args]}]
+  [args]
   (log/info "workflow:" args)
   ;; invoke activities with various synthetic delays.  The last entry, index 4, should be the fastest
   (let [requests (map-indexed (fn [i x] (invoke {:id i :delay x})) [600 400 200 100 10])]

--- a/test/temporal/test/raw_signal.clj
+++ b/test/temporal/test/raw_signal.clj
@@ -1,0 +1,29 @@
+;; Copyright © Manetu, Inc.  All rights reserved
+
+(ns temporal.test.raw-signal
+  (:require [clojure.test :refer :all]
+            [temporal.client.core :refer [>!] :as c]
+            [temporal.signals :refer [<!] :as s]
+            [temporal.workflow :refer [defworkflow] :as w]
+            [temporal.test.utils :as t]))
+
+(use-fixtures :once t/wrap-service)
+
+(def signal-name ::signal)
+
+(defworkflow raw-signal-workflow
+  [args]
+  (let [state (atom 0)]
+    (s/register-signal-handler! (fn [signal-name args]
+                                  (swap! state inc)))
+    (w/await (fn [] (> @state 1)))
+    @state))
+
+(deftest the-test
+  (testing "Verifies that we can handle raw signals"
+    (let [workflow (t/create-workflow raw-signal-workflow)]
+      (c/start workflow {})
+
+      (>! workflow signal-name {})
+      (>! workflow signal-name {})
+      (is (= 2 @(c/get-result workflow))))))

--- a/test/temporal/test/scale.clj
+++ b/test/temporal/test/scale.clj
@@ -20,7 +20,7 @@
     id))
 
 (defworkflow scale-workflow
-  [ctx {:keys [args]}]
+  [args]
   (log/info "workflow:" args)
   @(a/invoke scale-activity args))
 

--- a/test/temporal/test/sequence.clj
+++ b/test/temporal/test/sequence.clj
@@ -18,7 +18,7 @@
   (str "Hi, " args))
 
 (defworkflow sequence-workflow
-  [ctx _]
+  [_]
   @(-> (pt/resolved true)
        (p/then (fn [_]
                  (a/invoke sequence-activity "Bob")))

--- a/test/temporal/test/side_effect.clj
+++ b/test/temporal/test/side_effect.clj
@@ -12,7 +12,7 @@
 (use-fixtures :once t/wrap-service)
 
 (defworkflow side-effect-workflow
-  [ctx {:keys [args]}]
+  [args]
   (log/info "workflow:" args)
   (side-effect/now))
 

--- a/test/temporal/test/signal_timeout.clj
+++ b/test/temporal/test/signal_timeout.clj
@@ -4,7 +4,7 @@
   (:require [clojure.test :refer :all]
             [taoensso.timbre :as log]
             [temporal.client.core :refer [>!] :as c]
-            [temporal.signals :refer [<!]]
+            [temporal.signals :refer [<!] :as s]
             [temporal.workflow :refer [defworkflow]]
             [temporal.test.utils :as t])
   (:import [java.time Duration]))
@@ -14,10 +14,11 @@
 (def signal-name ::signal)
 
 (defworkflow timeout-workflow
-  [ctx {:keys [signals] :as args}]
+  [args]
   (log/info "timeout-workflow:" args)
-  (or (<! signals signal-name (Duration/ofSeconds 1))
-      :timed-out))
+  (let [signals (s/create-signal-chan)]
+    (or (<! signals signal-name (Duration/ofSeconds 1))
+        :timed-out)))
 
 (defn create []
   (let [wf (c/create-workflow (t/get-client) timeout-workflow {:task-queue t/task-queue})]

--- a/test/temporal/test/signal_with_start.clj
+++ b/test/temporal/test/signal_with_start.clj
@@ -4,7 +4,7 @@
   (:require [clojure.test :refer :all]
             [taoensso.timbre :as log]
             [temporal.client.core :as c]
-            [temporal.signals :refer [<!]]
+            [temporal.signals :refer [<!] :as s]
             [temporal.workflow :refer [defworkflow]]
             [temporal.activity :refer [defactivity] :as a]
             [temporal.test.utils :as t]))
@@ -19,9 +19,10 @@
   (str greeting ", " name))
 
 (defworkflow signal-greeter-workflow
-  [ctx {:keys [args signals]}]
+  [args]
   (log/info "greeter-workflow:" args)
-  (let [m (<! signals signal-name)]
+  (let [signals (s/create-signal-chan)
+        m (<! signals signal-name)]
     @(a/invoke signal-greet-activity (merge args m))))
 
 (deftest the-test

--- a/test/temporal/test/simple.clj
+++ b/test/temporal/test/simple.clj
@@ -16,7 +16,7 @@
   (str "Hi, " name))
 
 (defworkflow simple-greeter-workflow
-  [ctx {:keys [args]}]
+  [args]
   (log/info "greeter-workflow:" args)
   @(a/invoke simple-greet-activity args))
 

--- a/test/temporal/test/sleep.clj
+++ b/test/temporal/test/sleep.clj
@@ -12,7 +12,7 @@
 (use-fixtures :once t/wrap-service)
 
 (defworkflow sleep-workflow
-  [ctx {:keys [signals] :as args}]
+  [args]
   (log/info "sleep-workflow:" args)
   (w/sleep (Duration/ofSeconds 1))
   :ok)

--- a/test/temporal/test/tracing.clj
+++ b/test/temporal/test/tracing.clj
@@ -36,7 +36,7 @@
 ;;-----------------------------------------------------------------------------
 
 (defworkflow traced-workflow
-  [ctx {:keys [args]}]
+  [args]
   (log/info "traced-workflow:" args)
   :ok)
 

--- a/test/temporal/test/uuid_test.clj
+++ b/test/temporal/test/uuid_test.clj
@@ -11,7 +11,7 @@
 (use-fixtures :once t/wrap-service)
 
 (defworkflow uuid-workflow
-  [ctx args]
+  [args]
   (log/info "workflow:" args)
   (gen-uuid))
 

--- a/test/temporal/test/workflow_signal.clj
+++ b/test/temporal/test/workflow_signal.clj
@@ -4,7 +4,7 @@
   (:require [clojure.test :refer :all]
             [taoensso.timbre :as log]
             [temporal.client.core :as c]
-            [temporal.signals :refer [<! >!]]
+            [temporal.signals :refer [<! >!] :as s]
             [temporal.workflow :refer [defworkflow]]
             [temporal.test.utils :as t]))
 
@@ -13,12 +13,13 @@
 (def signal-name ::signal)
 
 (defworkflow wfsignal-primary-workflow
-  [ctx {:keys [signals] :as args}]
+  [args]
   (log/info "primary-workflow:" args)
-  (<! signals signal-name))
+  (let [signals (s/create-signal-chan)]
+    (<! signals signal-name)))
 
 (defworkflow wfsignal-secondary-workflow
-  [ctx {{:keys [workflow-id msg]} :args}]
+  [{:keys [workflow-id msg]}]
   (log/info "secondary-workflow:" msg)
   (>! workflow-id signal-name msg))
 


### PR DESCRIPTION
This patch breaks out the signal handling such that the core.async abstraction surrounding signals is now optional.  There is a new function:

           temporal.signals/register-signal-handler!

that offers low-level access to the signal callback.  The design was inspired by the work of Thomas Moerman (https://github.com/tmoerman) in the Query support

(See https://github.com/manetu/temporal-clojure-sdk/commit/4f052aeecd5d36cac0d1c2e1e95b72b23e5b2be7)

This work prompted another cleanup that I had been meaning to do: the removal of the 'ctx' from the defworkflow.  The original design had both defworkflow and defactivity receiving a user supplied 'ctx', but this never made sense for workflows since the context invites non-determinism.

So, the new signature of defworkflow is simply a single-arity function that receives the arguments directly, rather than within a {:keys [signals args]} map.  We still support 2-arity clients (for now) with a backwards compatibility check within the macro.  This may be removed in a future release, so we print a WARN to signal the developer of the deprecation.