### PR TITLE
Fix copy+paste error in local-invoke

### DIFF
--- a/src/temporal/activity.clj
+++ b/src/temporal/activity.clj
@@ -126,7 +126,7 @@ Arguments:
 (local-invoke my-activity {:foo \"bar\"} {:start-to-close-timeout (Duration/ofSeconds 3))
 ```
 "
-  ([activity params] (invoke activity params {}))
+  ([activity params] (local-invoke activity params {}))
   ([activity params options]
    (let [act-name (a/get-annotation activity)
          stub (Workflow/newUntypedLocalActivityStub (a/local-invoke-options-> options))]


### PR DESCRIPTION
Special thanks to Dan O'Reilly (@dano) for spying the problem and to Quinn Klassen (https://github.com/Quinn-With-Two-Ns) for helping to narrow it down and away from the Temporal Java SDK.