### PR TITLE
Temporal schedule support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ pom.xml.asc
 .hg/
 .idea*
 *.iml
+.calva/
+.lsp/
+.clj-kondo/

--- a/doc/clients.md
+++ b/doc/clients.md
@@ -4,9 +4,13 @@
 
 To initialize a Workflow Client, create an instance of a Workflow client with [temporal.client.core/create-client](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.core#create-client), create a Workflow stub with [temporal.client.core/create-workflow](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.core#create-workflow), and invoke the Workflow with [temporal.client.core/start](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.core#start)).  Finally, gather the results of the Workflow with [temporal.client.core/get-result](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.core#get-result).
 
+To initialize a Schedule Client, create an instance of a Schedule client with [temporal.client.schedule/create-client](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.schedule#create-client), create a Schedule with [temporal.client.schedule/schedule](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.schedule#schedule), and run a scheduled workflow execution immediately with [temporal.client.schedule/execute](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.schedule#execute)).
+
 ## Details
 
-To start a Workflow Execution, your Temporal Server must be running, and your front-end service must be accepting gRPC calls.
+Using the namespace `temporal.client.core` or `temporal.client.schedule`
+
+To start a Workflow Execution or manage a Scheduled Workflow Execution, your Temporal Server must be running, and your front-end service must be accepting gRPC calls.
 
 You can provide options to (create-client) to establish a connection to the specifics of the Temporal front-end service in your environment.
 
@@ -14,7 +18,9 @@ You can provide options to (create-client) to establish a connection to the spec
 (create-client {:target "temporal-frontend:7233" :namespace "my-namespace"})
 ```
 
-After establishing a successful connection to the Temporal Frontend Service, you may perform operations such as:
+### Workflow Executions
+
+After establishing a successful connection to the Temporal Frontend Service, you may perform Workflow Execution specific operations such as:
 
 - **Starting Workflows**: See [temporal.client.core/start](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.core#start) and [temporal.client.core/signal-with-start](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.core#signal-with-start)
 - **Signaling Workflows**: See [temporal.client.core/>!](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.core#%3E!) and [temporal.client.core/signal-with-start](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.core#signal-with-start)
@@ -52,3 +58,71 @@ We can create a client to invoke our Workflow as follows:
 ```
 
 Evaluating this code should result in `Hi, Bob` appearing on the console.  Note that (get-result) returns a promise, thus requiring a dereference.
+
+### Scheduled Workflow Executions
+
+After establishing a successful connection to the Temporal Frontend Service, you may perform Schedule specific operations such as:
+
+- **Creating Schedules**: See [temporal.client.schedule/schedule](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.schedule/schedule)
+- **Describing Schedules**: See [temporal.client.schedule/describe](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.schedule/describe)
+- **Pausing Schedules**: See [temporal.client.schedule/pause](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.schedule/pause)
+- **Unpausing Schedules**:  See [temporal.client.schedule/unpause](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.schedule/unpause)
+- **Removing Schedules**:  See [temporal.client.schedule/unschedule](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.schedule/unschedule)
+- **Triggering Schedules**: See [temporal.client.schedule/execute](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.schedule/execute)
+- **Updating Schedules**: See [temporal.client.schedule/reschedule](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.client.schedule/reschedule)
+
+Schedules can be built with cron expressions or built in Temporal time types.
+
+Schedules can executed immediately via "triggering" them.
+
+Schedules will handle overlapping runs determined by the `SchedulePolicy` you give it when creating it.
+
+Example Usage
+
+As a simple example, for the following Workflow implementation:
+
+```clojure
+(require '[temporal.workflow :refer [defworkflow]])
+(require '[temporal.activity :refer [defactivity] :as a])
+
+(defactivity greet-activity
+  [ctx {:keys [name] :as args}]
+  (log/info "greet-activity:" args)
+  (str "Hi, " name))
+
+(defworkflow greeter-workflow
+  [args]
+  (log/info "greeter-workflow:" args)
+  @(a/invoke greet-activity args))
+```
+
+Create and manage a schedule as follows
+
+
+```clojure
+(require '[temporal.client.schedule :as s])
+(let [client-options {:target "localhost:7233"
+                      :namespace "default"
+                      :enable-https false}
+      task-queue "MyTaskQueue"
+      workflow-id "my-workflow"
+      schedule-id "my-schedule"
+      client (s/create-client client-options)]
+  (s/schedule client schedule-id {:schedule {:trigger-immediately? true
+                                             :memo "Created by John Doe"}
+                                  :spec {:cron-expressions ["0 0 * * *"]
+                                         :timezone "US/Central"}
+                                  :policy {:pause-on-failure? false
+                                           :catchup-window (Duration/ofSeconds 10)
+                                         :overlap :skip}
+                                  :action {:arguments {:name "John"}
+                                           :options {:workflow-id workflow-id
+                                                     :task-queue task-queue}
+                                           :workflow-type greeter-workflow}})
+  (s/describe client schedule-id)
+  (s/pause client schedule-id)
+  (s/unpause client schedule-id)
+  (s/execute client schedule-id :skip)
+  (s/reschedule client schedule-id {:spec {:cron-expressions ["0 1 * * *"]}})
+  (s/unschedule client schedule-id))
+```

--- a/src/temporal/client/options.clj
+++ b/src/temporal/client/options.clj
@@ -1,0 +1,24 @@
+(ns temporal.client.options
+  (:require [temporal.internal.utils :as u])
+  (:import [io.temporal.client WorkflowClientOptions WorkflowClientOptions$Builder]
+           [io.temporal.common.interceptors WorkflowClientInterceptorBase]
+            [io.temporal.client.schedules ScheduleClientOptions ScheduleClientOptions$Builder]))
+
+(def ^:no-doc client-options
+  {:identity                  #(.setIdentity ^WorkflowClientOptions$Builder %1 %2)
+   :namespace                 #(.setNamespace ^WorkflowClientOptions$Builder %1 %2)
+   :data-converter            #(.setDataConverter ^WorkflowClientOptions$Builder %1 %2)
+   :interceptors              #(.setInterceptors ^WorkflowClientOptions$Builder %1 (into-array WorkflowClientInterceptorBase %2))})
+
+(defn ^:no-doc client-options->
+  ^WorkflowClientOptions [params]
+  (u/build (WorkflowClientOptions/newBuilder (WorkflowClientOptions/getDefaultInstance)) client-options params))
+
+(def ^:no-doc schedule-client-options
+  {:identity                  #(.setIdentity ^ScheduleClientOptions$Builder %1 %2)
+   :namespace                 #(.setNamespace ^ScheduleClientOptions$Builder %1 %2)
+   :data-converter            #(.setDataConverter ^ScheduleClientOptions$Builder %1 %2)})
+
+(defn ^:no-doc schedule-client-options->
+  ^ScheduleClientOptions [params]
+  (u/build (ScheduleClientOptions/newBuilder (ScheduleClientOptions/getDefaultInstance)) schedule-client-options params))

--- a/src/temporal/client/schedule.clj
+++ b/src/temporal/client/schedule.clj
@@ -1,0 +1,176 @@
+(ns temporal.client.schedule
+ (:require [taoensso.timbre :as log]
+           [temporal.client.options :as copts]
+           [temporal.internal.grpc :as g]
+           [temporal.internal.utils :as u]
+           [temporal.internal.schedule :as s])
+ (:import [java.time Duration]
+          [io.temporal.client.schedules ScheduleClient ScheduleUpdate ScheduleUpdateInput]))
+
+(set! *warn-on-reflection* true)
+
+(defn create-client
+  "Creates a `ScheduleClient` instance suitable for interacting with Temporal's Schedules.
+   The `ScheduleClient` has slightly less options then the `WorkflowClient` but it is mostly the same otherwise.
+
+   Arguments:
+
+   - `options`: Client configuration option map (See below)
+   - `timeout`: Connection timeout as a [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) (default: 5s)
+
+    #### options map
+
+
+   | Value                     | Description                                                                 | Type         | Default |
+   | ------------------------- | --------------------------------------------------------------------------- | ------------ | ------- |
+   | :target                   | Sets the connection host:port                                               | String       | \"127.0.0.1:7233\" |
+   | :identity                 | Overrides the worker node identity (workers only)                           | String       | |
+   | :namespace                | Sets the Temporal namespace context for this client                         | String       | |
+   | :data-converter           | Overrides the data converter used to serialize arguments and results.       | [DataConverter](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/common/converter/DataConverter.html) | |
+   | :channel                  | Sets gRPC channel to use. Exclusive with target and sslContext              | [ManagedChannel](https://grpc.github.io/grpc-java/javadoc/io/grpc/ManagedChannel.html) | |
+   | :ssl-context              | Sets gRPC SSL Context to use (See [[temporal.tls/new-ssl-context]])         | [SslContext](https://netty.io/4.0/api/io/netty/handler/ssl/SslContext.html) | |
+   | :enable-https             | Sets option to enable SSL/TLS/HTTPS for gRPC                                | boolean      | false |
+   | :rpc-timeout              | Sets the rpc timeout value for non query and non long poll calls            | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | 10s |
+   | :rpc-long-poll-timeout    | Sets the rpc timeout value                                                  | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | 60s |
+   | :rpc-query-timeout        | Sets the rpc timeout for queries                                            | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | 10s |
+   | :backoff-reset-freq       | Sets frequency at which gRPC connection backoff should be reset practically | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | 10s |
+   | :grpc-reconnect-freq      | Sets frequency at which gRPC channel will be moved into an idle state       | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | 60s |
+   | :headers                  | Set the headers                                                             | [Metadata](https://grpc.github.io/grpc-java/javadoc/io/grpc/Metadata.html) | |
+   | :enable-keepalive         | Set keep alive ping from client to the server                               | boolean       | false |
+   | :keepalive-time           | Set the keep alive time                                                     | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | |
+   | :keepalive-timeout        | Set the keep alive timeout                                                  | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | |
+   | :keepalive-without-stream | Set if client sends keepalive pings even with no active RPCs                | boolean       | false |
+   | :metrics-scope            | The scope to be used for metrics reporting                                  | [Scope](https://github.com/uber-java/tally/blob/master/core/src/main/java/com/uber/m3/tally/Scope.java) | |"
+  ([options] (create-client options (Duration/ofSeconds 5)))
+  ([options timeout]
+   (let [service (g/service-stub-> options timeout)]
+     (ScheduleClient/newInstance service (copts/schedule-client-options-> options)))))
+
+(defn schedule
+  "Creates a `Schedule` with Temporal
+
+   Arguments:
+
+   - `client`: [ScheduleClient]https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/client/schedules/ScheduleClient.html
+   - `schedule-id`: The string name of the schedule in Temporal, keeping it consistent with workflow id is a good idea
+   - `options`: A map containing the `:schedule`, `:state`, `:policy`, `:spec`, and `:action` option maps for the `Schedule`
+
+   ```clojure
+   (defworkflow my-workflow
+     [ctx args]
+     ...)
+
+   (let [client (create-client {:target \"localhost:8080\"})]
+   (create
+      client
+      \"my-workflow\"
+      {:schedule {:trigger-immediately? false}
+       :state {:paused? false}
+       :policy {:pause-on-failure? true}
+       :spec {:crons [\"0 * * * *\"]}
+       :action {:workflow-type my-workflow
+                :arguments {:value 1}
+                :options {:workflow-id \"my-workflow\"}}}))
+   ```"
+  [^ScheduleClient client schedule-id options]
+  (let [schedule (s/schedule-> options)
+        schedule-options (s/schedule-options-> options)]
+    (log/tracef "create schedule:" schedule-id)
+    (.createSchedule client schedule-id schedule schedule-options)))
+
+(defn unschedule
+  "Deletes a Temporal `Schedule` via a schedule-id
+
+    ```clojure
+
+   (let [client (create-client {:target \"localhost:8080\"})]
+      (unschedule client \"my-schedule\")
+    ```"
+  [^ScheduleClient client schedule-id]
+  (log/tracef "remove schedule:" schedule-id)
+  (-> client
+      (.getHandle schedule-id)
+      (.delete)))
+
+(defn describe
+  "Describes an existing Temporal `Schedule` via a schedule-id
+
+   ```clojure
+
+   (let [client (create-client {:target \"localhost:8080\"})]
+      (describe client \"my-schedule\")
+    ```"
+  [^ScheduleClient client schedule-id]
+  (-> client
+      (.getHandle schedule-id)
+      (.describe)))
+
+(defn pause
+  "Pauses an existing Temporal `Schedule` via a schedule-id
+
+   ```clojure
+
+   (let [client (create-client {:target \"localhost:8080\"})]
+      (pause client \"my-schedule\")
+    ```"
+  [^ScheduleClient client schedule-id]
+  (log/tracef "pausing schedule:" schedule-id)
+  (-> client
+      (.getHandle schedule-id)
+      (.pause)))
+
+(defn unpause
+  "Unpauses an existing Temporal `Schedule` via a schedule-id
+
+   ```clojure
+
+   (let [client (create-client {:target \"localhost:8080\"})]
+      (unpause client \"my-schedule\")
+    ```"
+  [^ScheduleClient client schedule-id]
+  (log/tracef "unpausing schedule:" schedule-id)
+  (-> client
+      (.getHandle schedule-id)
+      (.unpause)))
+
+(defn execute
+  "Runs a Temporal `Schedule's` workflow execution immediately via a schedule-id
+
+   ```clojure
+
+   (let [client (create-client {:target \"localhost:8080\"})]
+      (execute client \"my-schedule\" :skip)
+    ```"
+  [^ScheduleClient client schedule-id overlap-policy]
+  (log/tracef "execute schedule:" schedule-id)
+  (-> client
+      (.getHandle schedule-id)
+      (.trigger (s/overlap-policy-> overlap-policy))))
+
+(defn reschedule
+  "Updates the current Temporal `Schedule` via a schedule-id.
+   Uses the same options as create asside from `:schedule`
+
+   The `ScheduleHandle` takes a unary function object
+   of the signature:
+
+   (ScheduleUpdateInput) -> ScheduleUpdate
+
+   ```clojure
+
+   (let [client (create-client {:target \"localhost:8080\"})]
+      (reschedule client \"my-schedule\" {:spec {:crons [\"1 * * * *\"]}})
+   ```"
+  [^ScheduleClient client schedule-id options]
+  (log/tracef "update schedule:" schedule-id)
+  (letfn [(update-fn
+            [opts ^ScheduleUpdateInput input]
+            (let [schedule (-> input
+                               (.getDescription)
+                               (.getSchedule))]
+              (-> schedule
+                  (s/schedule-> opts)
+                  (ScheduleUpdate.))))]
+    (-> client
+        (.getHandle schedule-id)
+        (.update (u/->Func (partial update-fn options))))))

--- a/src/temporal/internal/grpc.clj
+++ b/src/temporal/internal/grpc.clj
@@ -1,0 +1,28 @@
+(ns ^:no-doc temporal.internal.grpc
+    (:require    [temporal.internal.utils :as u])
+    (:import [io.temporal.serviceclient WorkflowServiceStubs WorkflowServiceStubsOptions WorkflowServiceStubsOptions$Builder]))
+
+(def stub-options
+  {:channel                  #(.setChannel ^WorkflowServiceStubsOptions$Builder %1 %2)
+   :ssl-context              #(.setSslContext ^WorkflowServiceStubsOptions$Builder %1 %2)
+   :enable-https             #(.setEnableHttps ^WorkflowServiceStubsOptions$Builder %1 %2)
+   :target                   #(.setTarget ^WorkflowServiceStubsOptions$Builder %1 %2)
+   :rpc-timeout              #(.setRpcTimeout ^WorkflowServiceStubsOptions$Builder %1 %2)
+   :rpc-long-poll-timeout    #(.setRpcLongPollTimeout ^WorkflowServiceStubsOptions$Builder %1 %2)
+   :rpc-query-timeout        #(.setRpcQueryTimeout ^WorkflowServiceStubsOptions$Builder %1 %2)
+   :backoff-reset-freq       #(.setConnectionBackoffResetFrequency ^WorkflowServiceStubsOptions$Builder %1 %2)
+   :grpc-reconnect-freq      #(.setGrpcReconnectFrequency ^WorkflowServiceStubsOptions$Builder %1 %2)
+   :headers                  #(.setHeaders ^WorkflowServiceStubsOptions$Builder %1 %2)
+   :enable-keepalive         #(.setEnableKeepAlive ^WorkflowServiceStubsOptions$Builder %1 %2)
+   :keepalive-time           #(.setKeepAliveTime ^WorkflowServiceStubsOptions$Builder %1 %2)
+   :keepalive-timeout        #(.setKeepAliveTimeout ^WorkflowServiceStubsOptions$Builder %1 %2)
+   :keepalive-without-stream #(.setKeepAlivePermitWithoutStream ^WorkflowServiceStubsOptions$Builder %1 %2)
+   :metrics-scope            #(.setMetricsScope ^WorkflowServiceStubsOptions$Builder %1 %2)})
+
+(defn stub-options->
+  ^WorkflowServiceStubsOptions [params]
+  (u/build (WorkflowServiceStubsOptions/newBuilder) stub-options params))
+
+(defn service-stub->
+  [options timeout]
+  (WorkflowServiceStubs/newConnectedServiceStubs (stub-options-> options) timeout))

--- a/src/temporal/internal/schedule.clj
+++ b/src/temporal/internal/schedule.clj
@@ -1,0 +1,99 @@
+(ns ^:no-doc temporal.internal.schedule
+  (:require [clojure.walk :refer [stringify-keys]]
+            [temporal.internal.utils :as u]
+            [temporal.internal.workflow :as w])
+  (:import [io.temporal.api.enums.v1 ScheduleOverlapPolicy]
+           [io.temporal.client.schedules
+            Schedule
+            Schedule$Builder
+            ScheduleActionStartWorkflow
+            ScheduleActionStartWorkflow$Builder
+            ScheduleOptions
+            ScheduleOptions$Builder
+            SchedulePolicy
+            SchedulePolicy$Builder
+            ScheduleSpec
+            ScheduleSpec$Builder
+            ScheduleState
+            ScheduleState$Builder]))
+
+(set! *warn-on-reflection* true)
+
+(defn overlap-policy->
+  [overlap-policy]
+  (case overlap-policy
+    :allow ScheduleOverlapPolicy/SCHEDULE_OVERLAP_POLICY_ALLOW_ALL
+    :buffer ScheduleOverlapPolicy/SCHEDULE_OVERLAP_POLICY_BUFFER_ALL
+    :buffer-one ScheduleOverlapPolicy/SCHEDULE_OVERLAP_POLICY_BUFFER_ONE
+    :cancel ScheduleOverlapPolicy/SCHEDULE_OVERLAP_POLICY_CANCEL_OTHER
+    :skip ScheduleOverlapPolicy/SCHEDULE_OVERLAP_POLICY_SKIP
+    :terminate ScheduleOverlapPolicy/SCHEDULE_OVERLAP_POLICY_TERMINATE_OTHER))
+
+(def schedule-policy-spec
+  {:catchup-window        #(.setCatchupWindow ^SchedulePolicy$Builder %1 %2)
+   :overlap               (fn [^SchedulePolicy$Builder builder value]
+                            (.setOverlap builder (overlap-policy-> value)))
+   :pause-on-failure?     #(.setPauseOnFailure ^SchedulePolicy$Builder %1 %2)})
+
+(defn schedule-policy->
+  ^SchedulePolicy [params]
+  (u/build (SchedulePolicy/newBuilder) schedule-policy-spec params))
+
+(def schedule-spec-spec
+  {:calendars             #(.setCalendars​ ^ScheduleSpec$Builder %1 %2)
+   :cron-expressions      #(.setCronExpressions ^ScheduleSpec$Builder %1 %2)
+   :intervals             #(.setIntervals​ ^ScheduleSpec$Builder %1 %2)
+   :end-at                #(.setEndAt ^ScheduleSpec$Builder %1 %2)
+   :jitter                #(.setJitter ^ScheduleSpec$Builder %1 %2)
+   :skip-at               #(.setSkip ^ScheduleSpec$Builder %1 %2)
+   :start-at              #(.setStartAt ^ScheduleSpec$Builder %1 %2)
+   :timezone              #(.setTimeZoneName ^ScheduleSpec$Builder %1 %2)})
+
+(defn schedule-spec->
+  ^ScheduleSpec [params]
+  (u/build (ScheduleSpec/newBuilder) schedule-spec-spec params))
+
+(def schedule-action-start-workflow-spec->
+  {:options               #(.setOptions ^ScheduleActionStartWorkflow$Builder %1 (w/wf-options-> %2))
+   :arguments             (fn [^ScheduleActionStartWorkflow$Builder builder value]
+                            (.setArguments builder (to-array [(stringify-keys value)])))
+   :workflow-type         (fn [^ScheduleActionStartWorkflow$Builder builder value]
+                            (if (string? value)
+                              (.setWorkflowType builder ^String value)
+                              (.setWorkflowType builder (w/get-annotated-name value))))})
+
+(defn schedule-action-start-workflow->
+  ^ScheduleActionStartWorkflow [params]
+  (u/build
+   (ScheduleActionStartWorkflow/newBuilder)
+   schedule-action-start-workflow-spec-> params))
+
+(def schedule-state-spec
+  {:limited-action?       #(.setLimitedAction ^ScheduleState$Builder %1 %2)
+   :note                  #(.setNote ^ScheduleState$Builder %1 %2)
+   :paused?               #(.setPaused ^ScheduleState$Builder %1 %2)
+   :remaining-actions     #(.setRemainingActions ^ScheduleState$Builder %1 %2)})
+
+(defn schedule-state->
+  ^ScheduleState [params]
+  (u/build (ScheduleState/newBuilder) schedule-state-spec params))
+
+(def schedule-options-spec
+  {:memo                  #(.setMemo ^ScheduleOptions$Builder %1 %2)
+   :trigger-immediately?  #(.setTriggerImmediately ^ScheduleOptions$Builder %1 %2)})
+
+(defn schedule-options->
+  ^ScheduleOptions [params]
+  (u/build (ScheduleOptions/newBuilder) schedule-options-spec params))
+
+(def schedule-spec
+  {:action                #(.setAction ^Schedule$Builder %1 (schedule-action-start-workflow-> %2))
+   :policy                #(.setPolicy ^Schedule$Builder %1 (schedule-policy-> %2))
+   :spec                  #(.setSpec ^Schedule$Builder %1 (schedule-spec-> %2))
+   :state                 #(.setState ^Schedule$Builder %1 (schedule-state-> %2))})
+
+(defn schedule->
+  (^Schedule [params]
+   (u/build (Schedule/newBuilder) schedule-spec params))
+  (^Schedule [schedule params]
+   (u/build (Schedule/newBuilder schedule) schedule-spec params)))

--- a/src/temporal/internal/workflow.clj
+++ b/src/temporal/internal/workflow.clj
@@ -4,12 +4,15 @@
   (:require [clojure.core.protocols :as p]
             [clojure.datafy :as d]
             [slingshot.slingshot :refer [try+]]
-            [taoensso.timbre :as log]
             [taoensso.nippy :as nippy]
-            [temporal.internal.utils :as u]
+            [taoensso.timbre :as log]
+            [temporal.common :as common]
+            [temporal.internal.exceptions :as e]
             [temporal.internal.signals :as s]
-            [temporal.internal.exceptions :as e])
-  (:import [io.temporal.workflow Workflow WorkflowInfo]))
+            [temporal.internal.utils :as u])
+  (:import [io.temporal.api.enums.v1 WorkflowIdReusePolicy]
+           [io.temporal.client WorkflowOptions WorkflowOptions$Builder]
+           [io.temporal.workflow Workflow WorkflowInfo]))
 
 (extend-protocol p/Datafiable
   WorkflowInfo
@@ -19,6 +22,42 @@
      :run-id        (.getRunId d)
      :workflow-type (.getWorkflowType d)
      :attempt       (.getAttempt d)}))
+
+
+(def workflow-id-reuse-options
+  "
+| Value                        | Description                                                                  |
+| ---------------------------- | --------------------------------------------------------------------------- |
+| :allow-duplicate             | Allow starting a workflow execution using the same workflow id.             |
+| :allow-duplicate-failed-only | Allow starting a workflow execution using the same workflow id, only when the last execution's final state is one of [terminated, cancelled, timed out, failed] |
+| :reject-duplicate            | Do not permit re-use of the workflow id for this workflow.                  |
+| :terminate-if-running        | If a workflow is running using the same workflow ID, terminate it and start a new one. If no running workflow, then the behavior is the same as ALLOW_DUPLICATE|
+"
+  {:allow-duplicate             WorkflowIdReusePolicy/WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE
+   :allow-duplicate-failed-only WorkflowIdReusePolicy/WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY
+   :reject-duplicate            WorkflowIdReusePolicy/WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE
+   :terminate-if-running        WorkflowIdReusePolicy/WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING})
+
+(defn ^:no-doc workflow-id-reuse-policy->
+  ^WorkflowIdReusePolicy [policy]
+  (or (get workflow-id-reuse-options policy)
+      (throw (IllegalArgumentException. (str "Unknown workflow-id-reuse-policy: " policy " Must be one of " (keys workflow-id-reuse-options))))))
+
+(def ^:no-doc wf-option-spec
+  {:task-queue                 #(.setTaskQueue ^WorkflowOptions$Builder %1 (u/namify %2))
+   :workflow-id                #(.setWorkflowId ^WorkflowOptions$Builder %1 (u/namify %2))
+   :workflow-id-reuse-policy   #(.setWorkflowIdReusePolicy ^WorkflowOptions$Builder %1 (workflow-id-reuse-policy-> %2))
+   :workflow-execution-timeout #(.setWorkflowExecutionTimeout ^WorkflowOptions$Builder %1 %2)
+   :workflow-run-timeout       #(.setWorkflowRunTimeout ^WorkflowOptions$Builder %1 %2)
+   :workflow-task-timeout      #(.setWorkflowTaskTimeout ^WorkflowOptions$Builder %1 %2)
+   :retry-options              #(.setRetryOptions %1 (common/retry-options-> %2))
+   :cron-schedule              #(.setCronSchedule ^WorkflowOptions$Builder %1 %2)
+   :memo                       #(.setMemo ^WorkflowOptions$Builder %1 %2)
+   :search-attributes          #(.setSearchAttributes ^WorkflowOptions$Builder %1 %2)})
+
+(defn ^:no-doc wf-options->
+  ^WorkflowOptions [params]
+  (u/build (WorkflowOptions/newBuilder (WorkflowOptions/getDefaultInstance)) wf-option-spec params))
 
 (defn get-info []
   (d/datafy (Workflow/getInfo)))

--- a/src/temporal/testing/env.clj
+++ b/src/temporal/testing/env.clj
@@ -3,14 +3,15 @@
 (ns temporal.testing.env
   "Methods and utilities to assist with unit-testing Temporal workflows"
   (:require [temporal.client.worker :as worker]
-            [temporal.client.core :as client]
+            [temporal.client.options :as copts]
+            [temporal.internal.grpc :as g]
             [temporal.internal.utils :as u])
   (:import [io.temporal.testing TestWorkflowEnvironment TestEnvironmentOptions TestEnvironmentOptions$Builder]))
 
 (def ^:no-doc test-env-options
   {:worker-factory-options         #(.setWorkerFactoryOptions ^TestEnvironmentOptions$Builder %1 (worker/worker-factory-options-> %2))
-   :workflow-client-options        #(.setWorkflowClientOptions ^TestEnvironmentOptions$Builder %1 (client/client-options-> %2))
-   :workflow-service-stub-options  #(.setWorkflowServiceStubsOptions ^TestEnvironmentOptions$Builder %1 (client/stub-options-> %2))
+   :workflow-client-options        #(.setWorkflowClientOptions ^TestEnvironmentOptions$Builder %1 (copts/client-options-> %2))
+   :workflow-service-stub-options  #(.setWorkflowServiceStubsOptions ^TestEnvironmentOptions$Builder %1 (g/stub-options-> %2))
    :metrics-scope                  #(.setMetricsScope ^TestEnvironmentOptions$Builder %1 %2)})
 
 (defn ^:no-doc test-env-options->
@@ -32,8 +33,8 @@ Arguments:
 | Value                           | Description                                   | Type         | Default |
 | -------------------------       | --------------------------------------------- | ------------ | ------- |
 | :worker-factory-options         |                                               | [[worker/worker-factory-options]] | |
-| :workflow-client-options        |                                               | [[client/client-options]] | |
-| :workflow-service-stub-options  |                                               | [[client/stub-options]] | |
+| :workflow-client-options        |                                               | [[copts/client-options]] | |
+| :workflow-service-stub-options  |                                               | [[grpc/stub-options]] | |
 | :metrics-scope                  | The scope to be used for metrics reporting    | [Scope](https://github.com/uber-java/tally/blob/master/core/src/main/java/com/uber/m3/tally/Scope.java) | |
 
 

--- a/test/temporal/test/schedule.clj
+++ b/test/temporal/test/schedule.clj
@@ -1,0 +1,146 @@
+(ns temporal.test.schedule
+  (:require [clojure.test :refer :all]
+            [temporal.client.schedule :as schedule]
+            [temporal.internal.schedule :as s]
+            [temporal.internal.workflow :as w]
+            [temporal.test.utils :as t]
+            [temporal.workflow :refer [defworkflow]])
+  (:import [io.temporal.client.schedules ScheduleClient ScheduleHandle ScheduleUpdateInput ScheduleDescription]
+           [java.time Duration Instant]))
+
+(def workflow-id "simple-workflow")
+(def schedule-id "simple-workflow-schedule")
+(defworkflow simple-workflow [ctx args] args)
+
+(defn create-mocked-schedule-handle
+  [state]
+  (reify ScheduleHandle
+    (update [_ update-fn]
+      (swap! state update :update assoc :update-fn update-fn))
+    (delete [_]
+      (swap! state update :delete (fnil inc 0)))
+    (describe [_]
+      (swap! state update :describe (fnil inc 0))
+      nil)
+    (pause [_]
+      (swap! state update :pause (fnil inc 0)))
+    (unpause [_]
+      (swap! state update :unpause (fnil inc 0)))
+    (trigger [_ overlap-policy]
+      (swap! state update :trigger assoc :overlap-policy overlap-policy))))
+
+(defn create-mocked-schedule-client
+  [state]
+  (reify ScheduleClient
+    (createSchedule [_ schedule-id schedule schedule-options]
+      (swap! state update :create assoc
+             :schedule-id schedule-id
+             :schedule schedule
+             :schedule-options schedule-options)
+      (create-mocked-schedule-handle state))
+    (getHandle [_ schedule-id]
+      (swap! state update :handle assoc :schedule-id schedule-id)
+      (create-mocked-schedule-handle state))))
+
+(defn- stub-schedule-options
+  [& {:keys [action spec policy state schedule]}]
+  {:action (merge {:arguments {:name "John Doe" :age 32}
+                   :options {:workflow-id workflow-id
+                             :task-queue t/task-queue}
+                   :workflow-type simple-workflow}
+                  action)
+   :spec (merge {:cron-expressions ["0 * * * * "]
+                 :end-at (Instant/now)
+                 :jitter (Duration/ofSeconds 1)
+                 :start-at (Instant/now)
+                 :timezone "US/Central"}
+                spec)
+   :policy (merge {:pause-on-failure? true
+                   :catchup-window (Duration/ofSeconds 1)
+                   :overlap :skip}
+                  policy)
+   :state (merge {:paused? true
+                  :note "note"
+                  :limited-action? false}
+                 state)
+   :schedule (merge {:trigger-immediately? true
+                     :memo "memo"}
+                    schedule)})
+
+;; NOTE: Temporal Schedules are not supported in the Temporal test environment
+;; hence the mocked ScheduleClient stubs for now
+
+(deftest schedule-workflow-test
+  (testing "scheduling a workflow is successful"
+    (let [state (atom {})
+          client (create-mocked-schedule-client state)]
+      (is (some? (schedule/schedule client schedule-id (stub-schedule-options))))
+      (is (= (get-in @state [:create :schedule-id]) schedule-id))
+      (is (= (-> (get-in @state [:create :schedule]) .getAction .getWorkflowType) (w/get-annotated-name simple-workflow)))
+      (is (= (-> (get-in @state [:create :schedule]) .getAction .getWorkflowType) "simple-workflow"))
+      (is (= (-> (get-in @state [:create :schedule]) .getAction .getOptions .getWorkflowId) workflow-id))
+      (is (= (-> (get-in @state [:create :schedule]) .getSpec .getCronExpressions) ["0 * * * * "]))
+      (is (-> (get-in @state [:create :schedule]) .getPolicy .isPauseOnFailure))
+      (is (= (-> (get-in @state [:create :schedule]) .getState .getNote) "note"))
+      (is (-> (get-in @state [:create :schedule]) .getState .isPaused)))))
+
+(deftest unschedule-scheduled-workflow-test
+  (testing "unscheduling a scheduled workflow is successful"
+    (let [state (atom {})
+          client (create-mocked-schedule-client state)]
+      (schedule/unschedule client schedule-id)
+      (is (= (:delete @state) 1)))))
+
+(deftest describe-scheduled-workflow-test
+  (testing "describing a scheduled workflow is successful"
+    (let [state (atom {})
+          client (create-mocked-schedule-client state)]
+      (schedule/describe client schedule-id)
+      (is (= (:describe @state) 1)))))
+
+(deftest pause-scheduled-workflow-test
+  (testing "pauses a scheduled workflow is successful"
+    (let [state (atom {})
+          client (create-mocked-schedule-client state)]
+      (schedule/pause client schedule-id)
+      (is (= (:pause @state) 1)))))
+
+(deftest unpause-scheduled-workflow-test
+  (testing "unpauses a scheduled workflow is successful"
+    (let [state (atom {})
+          client (create-mocked-schedule-client state)]
+      (schedule/unpause client schedule-id)
+      (is (= (:unpause @state) 1)))))
+
+(deftest execute-scheduled-workflow-test
+  (testing "executes a scheduled workflow is successful"
+    (let [state (atom {})
+          client (create-mocked-schedule-client state)]
+      (schedule/execute client schedule-id :skip)
+      (is (= (get-in @state [:trigger :overlap-policy])
+             (s/overlap-policy-> :skip))))))
+
+(deftest reschedule-scheduled-workflow-test
+  (testing "reschedules/updates a scheduled workflow is successful"
+    (let [state (atom {})
+          client (create-mocked-schedule-client state)
+          update-options (stub-schedule-options :spec {:cron-expressions ["1 * * * *"]})
+          schedule-update-input (ScheduleUpdateInput.
+                                 (ScheduleDescription.
+                                  schedule-id
+                                  nil
+                                  (s/schedule-> (stub-schedule-options))
+                                  nil
+                                  nil
+                                  nil
+                                  nil))]
+      (schedule/reschedule client schedule-id update-options)
+      ;; validate the actual update function works
+      (is (= (-> (get-in @state [:update :update-fn])
+                 (.apply schedule-update-input)
+                 (.getSchedule)
+                 (.getSpec)
+                 (.getCronExpressions))
+             (-> (s/schedule-> update-options)
+                 (.getSpec)
+                 (.getCronExpressions)))))))

--- a/test/temporal/test/types.clj
+++ b/test/temporal/test/types.clj
@@ -2,54 +2,55 @@
 
 (ns temporal.test.types
   (:require [clojure.test :refer :all]
-            [temporal.client.core :as client]
-            [temporal.client.worker :as worker])
-  (:import [java.time Duration]
+            [temporal.client.worker :as worker]
+            [temporal.client.options :as o]
+            [temporal.internal.workflow :as w]
+            [temporal.internal.schedule :as s]
+            [temporal.internal.grpc :as g])
+  (:import [java.time Duration Instant]
            [io.grpc Grpc InsecureChannelCredentials Metadata]
            [io.grpc.netty.shaded.io.grpc.netty GrpcSslContexts]))
 
 (deftest workflow-options
   (testing "Verify that our workflow options work"
-    (let [x (client/wf-options-> {:workflow-id "foo"
-                                  :task-queue "bar"
-                                  :workflow-execution-timeout (Duration/ofSeconds 1)
-                                  :workflow-run-timeout (Duration/ofSeconds 1)
-                                  :workflow-task-timeout (Duration/ofSeconds 1)
-                                  :retry-options {:maximum-attempts 1}
-                                  :cron-schedule "* * * * *"
-                                  :memo {"foo" "bar"}
-                                  :search-attributes {"foo" "bar"}})]
+    (let [x (w/wf-options-> {:workflow-id "foo"
+                             :task-queue "bar"
+                             :workflow-execution-timeout (Duration/ofSeconds 1)
+                             :workflow-run-timeout (Duration/ofSeconds 1)
+                             :workflow-task-timeout (Duration/ofSeconds 1)
+                             :retry-options {:maximum-attempts 1}
+                             :cron-schedule "* * * * *"
+                             :memo {"foo" "bar"}
+                             :search-attributes {"foo" "bar"}})]
       (is (-> x (.getWorkflowId) (= "foo")))
       (is (-> x (.getTaskQueue) (= "bar"))))))
 
 (deftest client-options
   (testing "Verify that our stub options work"
-    (let [x (client/stub-options-> {:channel                    (-> (Grpc/newChannelBuilder "foo:1234" (InsecureChannelCredentials/create))
-                                                                    (.build))
-                                    :ssl-context              (-> (GrpcSslContexts/forClient)
-                                                                  (.build))
-                                    :target                   "foo:1234"
-                                    :enable-https             false
-                                    :rpc-timeout              (Duration/ofSeconds 1)
-                                    :rpc-long-poll-timeout    (Duration/ofSeconds 1)
-                                    :rpc-query-timeout        (Duration/ofSeconds 1)
-                                    :backoff-reset-freq       (Duration/ofSeconds 1)
-                                    :grpc-reconnect-freq      (Duration/ofSeconds 1)
-                                    :headers                  (Metadata.)
-                                    :enable-keepalive         true
-                                    :keepalive-time           (Duration/ofSeconds 1)
-                                    :keepalive-timeout        (Duration/ofSeconds 1)
-                                    :keepalive-without-stream true})]
+    (let [x (g/stub-options-> {:channel                  (-> (Grpc/newChannelBuilder "foo:1234" (InsecureChannelCredentials/create)) (.build))
+                               :ssl-context              (-> (GrpcSslContexts/forClient) (.build))
+                               :target                   "foo:1234"
+                               :enable-https             false
+                               :rpc-timeout              (Duration/ofSeconds 1)
+                               :rpc-long-poll-timeout    (Duration/ofSeconds 1)
+                               :rpc-query-timeout        (Duration/ofSeconds 1)
+                               :backoff-reset-freq       (Duration/ofSeconds 1)
+                               :grpc-reconnect-freq      (Duration/ofSeconds 1)
+                               :headers                  (Metadata.)
+                               :enable-keepalive         true
+                               :keepalive-time           (Duration/ofSeconds 1)
+                               :keepalive-timeout        (Duration/ofSeconds 1)
+                               :keepalive-without-stream true})]
       (is (-> x (.getTarget) (= "foo:1234")))))
   (testing "Verify that our client options work"
-    (let [x (client/client-options-> {:identity "test"
+    (let [x (o/client-options-> {:identity "test"
                                       :namespace "test"})]
       (is (-> x (.getIdentity) (= "test")))
       (is (-> x (.getNamespace) (= "test")))))
   (testing "Verify that mixed client/stub options work"
     (let [options {:target "foo:1234" :namespace "default"}]
-      (is (some? (client/stub-options-> options)))
-      (is (some? (client/client-options-> options))))))
+      (is (some? (g/stub-options-> options)))
+      (is (some? (o/client-options-> options))))))
 
 (deftest worker-options
   (testing "Verify that our worker-options work"
@@ -65,3 +66,63 @@
                                       :max-taskqueue-activities-per-second             1.0
                                       :max-workers-activities-per-second               1.0})]
       (is (-> x (.isLocalActivityWorkerOnly) false?)))))
+
+(deftest schedule-client-options
+  (testing "Verify that our stub options work"
+    (let [x (g/stub-options-> {:channel                  (-> (Grpc/newChannelBuilder "foo:1234" (InsecureChannelCredentials/create)) (.build))
+                               :ssl-context              (-> (GrpcSslContexts/forClient) (.build))
+                               :target                   "foo:1234"
+                               :enable-https             false
+                               :rpc-timeout              (Duration/ofSeconds 1)
+                               :rpc-long-poll-timeout    (Duration/ofSeconds 1)
+                               :rpc-query-timeout        (Duration/ofSeconds 1)
+                               :backoff-reset-freq       (Duration/ofSeconds 1)
+                               :grpc-reconnect-freq      (Duration/ofSeconds 1)
+                               :headers                  (Metadata.)
+                               :enable-keepalive         true
+                               :keepalive-time           (Duration/ofSeconds 1)
+                               :keepalive-timeout        (Duration/ofSeconds 1)
+                               :keepalive-without-stream true})]
+      (is (-> x (.getTarget) (= "foo:1234")))))
+  (testing "Verify that our client options work"
+    (let [x (o/schedule-client-options-> {:identity "test"
+                                        :namespace "test"})]
+      (is (-> x (.getIdentity) (= "test")))
+      (is (-> x (.getNamespace) (= "test")))))
+  (testing "Verify that mixed client/stub options work"
+    (let [options {:target "foo:1234" :namespace "default"}]
+      (is (some? (g/stub-options-> options)))
+      (is (some? (o/schedule-client-options-> options))))))
+
+(deftest schedule-options
+  (testing "Verify that a schedule can be constructed with the action, spec, policy, and state"
+    (let [action {:arguments {:value 1}
+                  :options {:workflow-id "my-workflow-execution"
+                            :task-queue "queue"}
+                  :workflow-type "my-workflow"}
+          spec {:cron-expressions ["0 * * * * "]
+                :end-at (Instant/now)
+                :jitter (Duration/ofSeconds 1)
+                :start-at (Instant/now)
+                :timezone "US/Central"}
+          policy {:pause-on-failure? true
+                  :catchup-window (Duration/ofSeconds 1)
+                  :overlap :skip}
+          state {:paused? true
+                 :note "note"
+                 :limited-action? false}
+          schedule (s/schedule-> {:action action
+                                  :policy policy
+                                  :spec spec
+                                  :state state})]
+      (is (some? (s/schedule-action-start-workflow-> action)))
+      (is (some? (s/schedule-spec-> spec)))
+      (is (some? (s/schedule-policy-> policy)))
+      (is (some? (s/schedule-state-> state)))
+      (is (some? schedule))
+      (is (= "my-workflow" (-> schedule .getAction .getWorkflowType)))
+      (is (= "my-workflow-execution" (-> schedule .getAction .getOptions .getWorkflowId)))
+      (is (= ["0 * * * * "] (-> schedule .getSpec .getCronExpressions)))
+      (is (-> schedule .getPolicy .isPauseOnFailure))
+      (is (= "note" (-> schedule .getState .getNote)))
+      (is (-> schedule .getState .isPaused)))))


### PR DESCRIPTION
## Changes

Added support for Temporal's Schedule feature to this SDK. My company has been using these wrappers we wrote locally for quite a while and they have been battle tested. I thought it would be good to give back to the community.

[Temporal Java SDK](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/client/schedules/package-summary.html)

[Schedule How-To](https://docs.temporal.io/dev-guide/java/features#schedule-a-workflow)

- Implement core builders for `Schedule`, `SchedulePolicy`, `ScheduleSpec`, `ScheduleState`, `ScheduleActionStartWorkflow`, and `ScheduleOptions` in `internal/schedule.clj`
- Implement `ScheduleClient` and associated operations in `client/schedule.clj`
- Move `grpc` related stub code to `internal/grpc.clj` so both clients can share
- Move `workflow` options back to `internal/workflow.clj` so both clients can share
- Move client options to `client/options.clj`
- Update `test/types.clj` with new Schedule related builder tests
- Create `test/schedule.clj` with new Schedule related operation tests
- Update the `doc/clients.md` to include `ScheduleClient` documentation

## Review Checklist

- [x] Performed a self-review of my code
- [x] Added thorough tests
- [x] Run the documentation examples in the REPL locally against Temporal

## Issue ticket number and link

N/A