### PR TITLE
schedule's args serdes should adhere to this SDKs protocol

### DIFF
--- a/src/temporal/internal/schedule.clj
+++ b/src/temporal/internal/schedule.clj
@@ -56,7 +56,7 @@
 (def schedule-action-start-workflow-spec->
   {:options               #(.setOptions ^ScheduleActionStartWorkflow$Builder %1 (w/wf-options-> %2))
    :arguments             (fn [^ScheduleActionStartWorkflow$Builder builder value]
-                            (.setArguments builder (to-array [(stringify-keys value)])))
+                            (.setArguments builder (u/->objarray value)))
    :workflow-type         (fn [^ScheduleActionStartWorkflow$Builder builder value]
                             (if (string? value)
                               (.setWorkflowType builder ^String value)


### PR DESCRIPTION
Args typically are serialized and deserialized using objarray-> and args-> (defined in temporal.internal.utils) so that data-conversion can transparently work with arbitrary data.  Schedule should adhere to this protocol and apply objarray-> on arguments so as to satisfy the args-> call when workflow is executed.

TODO: enhance UT to actually launch a workflow when base java library adds proper schedule support to its "testing" framework.