### PR TITLE
Add an `allSettled` promise handling function

### DIFF
--- a/src/temporal/client/schedule.clj
+++ b/src/temporal/client/schedule.clj
@@ -50,7 +50,7 @@
    ```"
   [^ScheduleClient client schedule-id options]
   (let [schedule (s/schedule-> options)
-        schedule-options (s/schedule-options-> options)]
+        schedule-options (s/schedule-options-> (:schedule options))]
     (log/tracef "create schedule:" schedule-id)
     (.createSchedule client schedule-id schedule schedule-options)))
 

--- a/src/temporal/internal/promise.clj
+++ b/src/temporal/internal/promise.clj
@@ -1,8 +1,7 @@
 ;; Copyright © Manetu, Inc.  All rights reserved
 
 (ns ^:no-doc temporal.internal.promise
-  (:require [taoensso.timbre :as log]
-            [promesa.protocols :as pt]
+  (:require [promesa.protocols :as pt]
             [temporal.internal.utils :refer [->Func] :as u])
   (:import [clojure.lang IDeref IBlockingDeref]
            [io.temporal.workflow Promise]

--- a/src/temporal/internal/schedule.clj
+++ b/src/temporal/internal/schedule.clj
@@ -1,6 +1,5 @@
 (ns ^:no-doc temporal.internal.schedule
-  (:require [clojure.walk :refer [stringify-keys]]
-            [temporal.internal.utils :as u]
+  (:require [temporal.internal.utils :as u]
             [temporal.internal.workflow :as w])
   (:import [io.temporal.api.enums.v1 ScheduleOverlapPolicy]
            [io.temporal.client.schedules

--- a/src/temporal/promise.clj
+++ b/src/temporal/promise.clj
@@ -47,7 +47,7 @@ For more Java SDK samples example look here:
 ```
 "
   [coll]
-  (letfn [(wait! [^Promise p] (try (.get p) ( catch Exception _)))]
+  (letfn [(wait! [^Promise p] (try (.get p) (catch Exception _)))]
     (-> (into-array Promise (mapv wait! (->array coll)))
         (Promise/allOf)
         (pt/->PromiseAdapter)

--- a/src/temporal/promise.clj
+++ b/src/temporal/promise.clj
@@ -30,6 +30,31 @@ promises returned from [[temporal.activity/invoke]] from within workflow context
       (p/then (fn [_]
                 (mapv deref coll)))))
 
+(defn allSettled
+  "Returns Promise that becomes completed when all arguments are completed, even in the face of errors.
+
+*N.B. You must handle the exceptions in the returned promises when done*
+
+Similar to [promesa/all](https://funcool.github.io/promesa/latest/promesa.core.html#var-all) but designed to work with
+promises returned from [[temporal.activity/invoke]] from within workflow context.
+
+For more Java SDK samples example look here:
+   https://github.com/temporalio/samples-java/tree/main/core/src/main/java/io/temporal/samples/batch
+
+```clojure
+(-> (allSettled [(a/invoke activity-a ..) (a/invoke activity-b ..)])
+    (promesa.core/then (fn [[a-result b-result]] ...)))
+```
+"
+  [coll]
+  (letfn [(wait! [^Promise p] (try (.get p) ( catch Exception _)))]
+    (-> (into-array Promise (mapv wait! (->array coll)))
+        (Promise/allOf)
+        (pt/->PromiseAdapter)
+        ;; The promises are all completed at this point,
+        ;; this is just to use the promesa library
+        (p/then (fn [_] (mapv deref coll))))))
+
 (defn race
   "Returns Promise that becomes completed when any of the arguments are completed.
 


### PR DESCRIPTION
I added a new promise handling function called `allSettled` historically in most programming languages this function name waits for every promise to finish running (or failing) before performing operations on them. 

I used this to wait for a batch of activities to run then handle the errors at the end if any exist.

I would like if I could implement here in the repository because leveraging the internals of the promise in the SDK here is a bit nasty to do in our repository. 

This is a lot cleaner and could be useful to others.

I implemented the feature like this because of these two examples (as maxim suggested)

1. https://github.com/temporalio/samples-java/tree/main/core/src/main/java/io/temporal/samples/batch

2. https://community.temporal.io/t/async-activities-in-workflow/896


SIDE NOTE:

Also fixes a bug in the scheduling code that was not pulling the `:schedule` key out of the options passed into the schedule like one would assume. 