### PR TITLE
add new all-settled promise handler

### DIFF
--- a/src/temporal/client/schedule.clj
+++ b/src/temporal/client/schedule.clj
@@ -50,7 +50,7 @@
    ```"
   [^ScheduleClient client schedule-id options]
   (let [schedule (s/schedule-> options)
-        schedule-options (s/schedule-options-> options)]
+        schedule-options (s/schedule-options-> (:schedule options))]
     (log/tracef "create schedule:" schedule-id)
     (.createSchedule client schedule-id schedule schedule-options)))
 

--- a/src/temporal/internal/promise.clj
+++ b/src/temporal/internal/promise.clj
@@ -1,8 +1,7 @@
 ;; Copyright © Manetu, Inc.  All rights reserved
 
 (ns ^:no-doc temporal.internal.promise
-  (:require [taoensso.timbre :as log]
-            [promesa.protocols :as pt]
+  (:require [promesa.protocols :as pt]
             [temporal.internal.utils :refer [->Func] :as u])
   (:import [clojure.lang IDeref IBlockingDeref]
            [io.temporal.workflow Promise]

--- a/src/temporal/internal/schedule.clj
+++ b/src/temporal/internal/schedule.clj
@@ -1,6 +1,5 @@
 (ns ^:no-doc temporal.internal.schedule
-  (:require [clojure.walk :refer [stringify-keys]]
-            [temporal.internal.utils :as u]
+  (:require [temporal.internal.utils :as u]
             [temporal.internal.workflow :as w])
   (:import [io.temporal.api.enums.v1 ScheduleOverlapPolicy]
            [io.temporal.client.schedules

--- a/src/temporal/promise.clj
+++ b/src/temporal/promise.clj
@@ -30,7 +30,7 @@ promises returned from [[temporal.activity/invoke]] from within workflow context
       (p/then (fn [_]
                 (mapv deref coll)))))
 
-(defn allSettled
+(defn all-settled
   "Returns Promise that becomes completed when all arguments are completed, even in the face of errors.
 
 *N.B. You must handle the exceptions in the returned promises when done*
@@ -42,7 +42,7 @@ For more Java SDK samples example look here:
    https://github.com/temporalio/samples-java/tree/main/core/src/main/java/io/temporal/samples/batch
 
 ```clojure
-(-> (allSettled [(a/invoke activity-a ..) (a/invoke activity-b ..)])
+(-> (all-settled [(a/invoke activity-a ..) (a/invoke activity-b ..)])
     (promesa.core/then (fn [[a-result b-result]] ...)))
 ```
 "

--- a/src/temporal/promise.clj
+++ b/src/temporal/promise.clj
@@ -47,13 +47,14 @@ For more Java SDK samples example look here:
 ```
 "
   [coll]
-  (letfn [(wait! [^Promise p] (try (.get p) (catch Exception _)))]
-    (-> (into-array Promise (mapv wait! (->array coll)))
-        (Promise/allOf)
-        (pt/->PromiseAdapter)
-        ;; The promises are all completed at this point,
-        ;; this is just to use the promesa library
-        (p/then (fn [_] (mapv deref coll))))))
+  (letfn [(wait! [^Promise p] (try (.get p) p (catch Exception _ p)))]
+    (->
+     (into-array Promise (mapv wait! (->array coll)))
+     (Promise/allOf)
+     (pt/->PromiseAdapter)
+       ;; The promises are all completed at this point,
+       ;; this is just to use the promesa library
+     (p/then (fn [_] (mapv deref coll))))))
 
 (defn race
   "Returns Promise that becomes completed when any of the arguments are completed.

--- a/src/temporal/promise.clj
+++ b/src/temporal/promise.clj
@@ -47,14 +47,16 @@ For more Java SDK samples example look here:
 ```
 "
   [coll]
-  (letfn [(wait! [^Promise p] (try (.get p) p (catch Exception _ p)))]
-    (->
-     (into-array Promise (mapv wait! (->array coll)))
-     (Promise/allOf)
-     (pt/->PromiseAdapter)
+  (letfn [(wait! [^Promise p] (try (.get p) (catch Exception _)))]
+    ;; So we do not have to duplicate this, make the only copy here
+    (let [promises (->array coll)]
+      (run! wait! promises)
+      (->
+       (Promise/allOf promises)
+       (pt/->PromiseAdapter)
        ;; The promises are all completed at this point,
        ;; this is just to use the promesa library
-     (p/then (fn [_] (mapv deref coll))))))
+       (p/then (fn [_] (mapv deref coll)))))))
 
 (defn race
   "Returns Promise that becomes completed when any of the arguments are completed.

--- a/src/temporal/promise.clj
+++ b/src/temporal/promise.clj
@@ -31,9 +31,9 @@ promises returned from [[temporal.activity/invoke]] from within workflow context
                 (mapv deref coll)))))
 
 (defn all-settled
-  "Returns Promise that becomes completed when all arguments are completed, even in the face of errors.
+  "Returns a Promise that becomes completed/failed when all the arguments are done/settled, even in the face of errors.
 
-*N.B. You must handle the exceptions in the returned promises when done*
+*N.B. You must handle the exceptions in the returned promise with promesa*
 
 Similar to [promesa/all](https://funcool.github.io/promesa/latest/promesa.core.html#var-all) but designed to work with
 promises returned from [[temporal.activity/invoke]] from within workflow context.

--- a/test/temporal/test/concurrency.clj
+++ b/test/temporal/test/concurrency.clj
@@ -73,7 +73,7 @@
       (c/start workflow {})
       (is (-> workflow c/get-result deref count (= 10)))))
   (testing "Testing that all-settled waits for all the activities to complete
-              just like `p/all` and can still propogate errors"
+                just like `p/all` and can still propogate errors"
     (let [workflow (t/create-workflow error-prone-workflow)]
       (c/start workflow {})
       (is (-> workflow c/get-result deref (= 5))))))

--- a/test/temporal/test/concurrency.clj
+++ b/test/temporal/test/concurrency.clj
@@ -56,12 +56,12 @@
        (p/catch (fn [e] (:args (ex-data e))))))
 
 (deftest test-all-settled
-  (testing "Testing that allSettled waits for all the activities to complete
+  (testing "Testing that all-settled waits for all the activities to complete
             just like `p/all` does in spite of errors"
     (let [workflow (t/create-workflow all-settled-workflow)]
       (c/start workflow {})
       (is (-> workflow c/get-result deref count (= 10)))))
-  (testing "Testing that allSettled waits for all the activities to complete
+  (testing "Testing that all-settled waits for all the activities to complete
             despite error and can return the errors"
     (let [workflow (t/create-workflow error-prone-workflow)]
       (c/start workflow {})


### PR DESCRIPTION
I added a new promise handling function called allSettled historically in most programming languages this function name waits for every promise to finish running (or failing) before performing operations on them.

This is really good for `batching` activities in a workflow or maybe one child workflows in a workflow

I used this to wait for a batch of activities to run then handle the errors at the end if any exist.

I would like it if I could implement the function in the repository because leveraging the internals of the temporal.promise in the SDK here is a bit nasty to do in our repository.

This is a lot cleaner and could be useful to others (at least I think so)

I implemented the feature like this because of these two examples from the Temporal core team (as maxim suggested)

1. https://github.com/temporalio/samples-java/tree/main/core/src/main/java/io/temporal/samples/batch

2. https://community.temporal.io/t/async-activities-in-workflow/896

SIDE NOTE:

Also fixes a bug in the scheduling code that was not pulling the :schedule key out of the options passed into the schedule like one would assume.
