### PR TITLE
Add clj-kondo exports

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [medley "1.4.0"]
                  [slingshot "0.12.2"]]
   :repl-options {:init-ns user}
-  :java-source-paths ["src"]
+  :java-source-paths ["src" "resources"]
   :javac-options ["-target" "11" "-source" "11"]
 
   :eastwood {:add-linters [:unused-namespaces]}

--- a/resources/clj-kondo.exports/io.github.manetu/temporal-sdk/config.edn
+++ b/resources/clj-kondo.exports/io.github.manetu/temporal-sdk/config.edn
@@ -1,0 +1,2 @@
+{:lint-as {temporal.workflow/defworkflow clojure.core/defn
+           temporal.activity/defactivity clojure.core/defn}}


### PR DESCRIPTION
Great library!

This configuration helps clj-kondo understand the `defworkflow` and `defactivity` macros.

Let me know if you have better ideas on how to organize the resources path. I thought `dev/user.clj`, `dev/utils.clj` and  `dev/resources` kinda made sense.