### PR TITLE
Remove the default options for child workflows

### DIFF
--- a/src/temporal/internal/child_workflow.clj
+++ b/src/temporal/internal/child_workflow.clj
@@ -30,12 +30,6 @@
    :cancellation-type          #(.setCancellationType ^ChildWorkflowOptions$Builder %1 (cancellation-type-> %2))
    :memo                       #(.setMemo ^ChildWorkflowOptions$Builder %1 %2)})
 
-(defn import-child-workflow-options
-  [{:keys [workflow-run-timeout workflow-execution-timeout] :as options}]
-  (cond-> options
-    (every? nil? [workflow-run-timeout workflow-execution-timeout])
-    (assoc :workflow-execution-timeout (Duration/ofSeconds 10))))
-
 (defn child-workflow-options->
   ^ChildWorkflowOptions [options]
-  (u/build (ChildWorkflowOptions/newBuilder) child-workflow-option-spec (import-child-workflow-options options)))
+  (u/build (ChildWorkflowOptions/newBuilder) child-workflow-option-spec options))


### PR DESCRIPTION
The default workflow options I set in the Clojure SDK do not reflect the defaults in the Java SDK. Workflow executions are always set to run indefinitely if the `workflow execution timeout` and `workflow run timeout` are not set. In order to stay consistent with the Java SDK we should reflect that here.

*This change is not backwards compatible and will require a new version to be cut*