### PR TITLE
REPL hot-reload for workers

### DIFF
--- a/doc/workers.md
+++ b/doc/workers.md
@@ -51,6 +51,25 @@ All visible defworkflow/defactivity functions are registered automatically, by d
 
 The Temporal Server adds a new task to the Workflows / Activity Task Queue whenever you start a Workflow or when a Workflow needs to invoke an Activity.  Any Worker polling that Task Queue that has the requested Workflow / Activity registered can pick up the new task and execute it.
 
+## Hot reloading during development
+
+By default, Workers capture the current function values when they start. For REPL-driven development, you can opt in to resolving Vars at execution time so re-evaluated `defactivity` and `defworkflow` forms can be picked up without restarting the Worker.
+
+```clojure
+(worker/start client {:task-queue task-queue
+                      :hot-reload-activities? true})
+```
+
+Activity hot reloading is usually the safest development option. Workflow hot reloading is also available, but should be used cautiously because Temporal workflows must remain deterministic during replay:
+
+```clojure
+(worker/start client {:task-queue task-queue
+                      :hot-reload-activities? true
+                      :hot-reload-workflows? true})
+```
+
+These options default to `false` and are intended for development / REPL use, not production deployments.
+
 ## Automatic Poller Scaling
 
 By default, Workers use a fixed number of pollers for each task type.  You can configure Workers to automatically scale the number of concurrent polls based on load using the poller behavior options:

--- a/project.clj
+++ b/project.clj
@@ -30,6 +30,7 @@
   :codox {:metadata {:doc/format :markdown}}
 
   :profiles {:dev {:dependencies   [[org.clojure/tools.namespace "1.5.1"]
+                                    [criterium "0.4.6"]
                                     [eftest "0.6.0"]
                                     [mockery "0.1.4"]
                                     [io.temporal/temporal-opentracing "1.32.1"]]

--- a/src/temporal/activity.clj
+++ b/src/temporal/activity.clj
@@ -163,8 +163,11 @@ Arguments:
   [name params* & body]
   (let [fqn (u/get-fq-classname name)
         sname (str name)]
-    `(def ~name ^{::a/def {:name ~sname :fqn ~fqn}}
-       (fn [ctx# args#]
-         (log/trace (str ~fqn ": ") args#)
-         (let [f# (fn ~params* (do ~@body))]
-           (f# ctx# args#))))))
+    `(def ~name
+       (with-meta
+         (fn [ctx# args#]
+           (log/trace (str ~fqn ": ") args#)
+           (let [f# (fn ~params* (do ~@body))]
+             (f# ctx# args#)))
+         {::a/def {:name ~sname :fqn ~fqn}
+          ::u/var (var ~name)}))))

--- a/src/temporal/client/worker.clj
+++ b/src/temporal/client/worker.clj
@@ -16,10 +16,14 @@
   "
 Initializes a worker instance, suitable for real connections or unit-testing with temporal.testing.env
 "
-  [^Worker worker {:keys [ctx] {:keys [activities workflows] :as dispatch} :dispatch}]
-  (let [dispatch (if (nil? dispatch)
-                   {:activities (a/auto-dispatch) :workflows (w/auto-dispatch)}
-                   {:activities (a/import-dispatch activities) :workflows (w/import-dispatch workflows)})]
+  [^Worker worker {:keys [ctx hot-reload-activities? hot-reload-workflows?] {:keys [activities workflows] :as dispatch} :dispatch}]
+  (let [activity-dispatch-opts {:hot-reload? hot-reload-activities?}
+        workflow-dispatch-opts {:hot-reload? hot-reload-workflows?}
+        dispatch (if (nil? dispatch)
+                   {:activities (a/auto-dispatch activity-dispatch-opts)
+                    :workflows  (w/auto-dispatch workflow-dispatch-opts)}
+                   {:activities (a/import-dispatch activities activity-dispatch-opts)
+                    :workflows  (w/import-dispatch workflows workflow-dispatch-opts)})]
     (log/trace "init:" dispatch)
     (.registerActivitiesImplementations worker (to-array [(a/dispatcher ctx (:activities dispatch))]))
     (.registerWorkflowImplementationFactory worker DynamicWorkflowProxy
@@ -83,6 +87,8 @@ Options for configuring workers (See [[start]])
 | :task-queue                                     | y         | The name of the task-queue for this worker instance to listen on.                                                                                                                                                                                 | String / keyword                                                               |                                                             |
 | :ctx                                            |           | An opaque handle that is passed back as the first argument of [[temporal.workflow/defworkflow]] and [[temporal.activity/defactivity]], useful for passing state such as database or network connections.                                          | <any>                                                                          | nil                                                         |
 | :dispatch                                       |           | An optional map explicitly setting the dispatch table                                                                                                                                                                                             | See below                                                                      | All visible activities/workers are automatically registered |
+| :hot-reload-activities?                         |           | When true, stores activity Vars in the dispatch table and dereferences them at execution time. Intended for development / REPL use.                                                                                                               | boolean                                                                        | false                                                       |
+| :hot-reload-workflows?                          |           | When true, stores workflow Vars in the dispatch table and dereferences them at execution time. Development-only; changing workflow code can break Temporal replay determinism.                                                                     | boolean                                                                        | false                                                       |
 | :default-deadlock-detection-timeout             |           | Time period in ms that will be used to detect workflow deadlock.                                                                                                                                                                                  | long                                                                           | 1000                                                        |
 | :default-heartbeat-throttle-interval            |           | Default amount of time between sending each pending heartbeat.                                                                                                                                                                                    | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | 30s                                                         |
 | :local-activity-worker-only                     |           | Worker should only handle workflow tasks and local activities.                                                                                                                                                                                    | boolean                                                                        | false                                                       |

--- a/src/temporal/internal/activity.clj
+++ b/src/temporal/internal/activity.clj
@@ -75,12 +75,16 @@
   (u/get-annotated-name x ::def))
 
 (defn auto-dispatch
-  []
-  (u/get-annotated-fns ::def))
+  ([]
+   (auto-dispatch {}))
+  ([opts]
+   (u/get-annotated-fns ::def opts)))
 
 (defn import-dispatch
-  [syms]
-  (u/import-dispatch ::def syms))
+  ([syms]
+   (import-dispatch syms {}))
+  ([syms opts]
+   (u/import-dispatch ::def syms opts)))
 
 (defn- export-result [activity-id x]
   (log/trace activity-id "result:" x)
@@ -107,7 +111,7 @@
 (defn- -execute
   [ctx dispatch args]
   (let [{:keys [activity-type activity-id] :as _info} (get-info)
-        f (u/find-dispatch-fn dispatch activity-type)
+        f (u/resolve-dispatch-fn (u/find-dispatch dispatch activity-type))
         a (u/->args args)]
     (log/trace activity-id "calling" f "with args:" a)
     (try+

--- a/src/temporal/internal/utils.clj
+++ b/src/temporal/internal/utils.clj
@@ -41,14 +41,16 @@
 
 (defn find-annotated-fns
   "Finds all instances of functions annotated with 'marker' via metadata and returns a [name fn] map"
-  [marker]
-  (->> (all-ns)
-       (mapcat (comp vals ns-interns ns-name))
-       (reduce (fn [acc x]
-                 (let [v (var-get x)
-                       m (get-annotation v marker)]
-                   (cond-> acc
-                     (some? m) (conj (assoc m :fn v))))) [])))
+  ([marker]
+   (find-annotated-fns marker {}))
+  ([marker {:keys [hot-reload?] :or {hot-reload? false}}]
+   (->> (all-ns)
+        (mapcat (comp vals ns-interns ns-name))
+        (reduce (fn [acc x]
+                  (let [v (var-get x)
+                        m (get-annotation v marker)]
+                    (cond-> acc
+                      (some? m) (conj (assoc m (if hot-reload? :var :fn) (if hot-reload? x v)))))) []))))
 
 (defn frequencies-by
   "a generalized version of frequencies"
@@ -70,10 +72,12 @@
         (throw (ex-info "conflict detected: All temporal workflows and activities must be uniquely named" {:conflicts data}))))))
 
 (defn get-annotated-fns
-  [marker]
-  (let [data (find-annotated-fns marker)]
-    (verify-registered-fns data)
-    (m/index-by :name data)))
+  ([marker]
+   (get-annotated-fns marker {}))
+  ([marker opts]
+   (let [data (find-annotated-fns marker opts)]
+     (verify-registered-fns data)
+     (m/index-by :name data))))
 
 (defn find-dispatch
   "Finds any dispatch descriptor named 't' that carry metadata 'marker'"
@@ -81,18 +85,50 @@
   (or (get dispatch-table t)
       (throw (ex-info "workflow/activity not found" {:function t}))))
 
+(defn resolve-dispatch-fn
+  "Resolves a dispatch entry to the current function value. If the entry stores a
+  Var, dereferences it at execution time so re-evaluated definitions are picked up."
+  [entry]
+  (if-let [v (:var entry)]
+    @v
+    (:fn entry)))
+
+(defn resolve-dispatch
+  "Resolves a dispatch entry, refreshing marker metadata from the current Var value
+  when possible. This keeps workflow metadata such as :type in sync during hot reload."
+  [marker entry]
+  (if-let [v (:var entry)]
+    (let [f @v]
+      (if-let [m (get-annotation f marker)]
+        (assoc m :var v :fn f)
+        (assoc entry :fn f)))
+    entry))
+
 (defn find-dispatch-fn
   "Finds any functions named 't' that carry metadata 'marker'"
   [dispatch-table t]
-  (:fn (find-dispatch dispatch-table t)))
+  (resolve-dispatch-fn (find-dispatch dispatch-table t)))
+
+(defn- dispatch-entry
+  [marker x hot-reload?]
+  (let [f (if (var? x) @x x)
+        {:keys [name] :as m} (get-annotation f marker)
+        v (or (when (var? x) x) (::var (meta f)))]
+    (when-not name
+      (throw (ex-info "bad symbol" {:message (str x " does not appear to be a valid symbol")})))
+    (if (and hot-reload? v)
+      (assoc m :var v)
+      (assoc m :fn f))))
 
 (defn import-dispatch
-  [marker coll]
-  (reduce (fn [acc s]
-            (let [{:keys [name] :as x} (get-annotation s marker)]
-              (assoc acc name (assoc x :fn s))))
-          {}
-          coll))
+  ([marker coll]
+   (import-dispatch marker coll {}))
+  ([marker coll {:keys [hot-reload?] :or {hot-reload? false}}]
+   (reduce (fn [acc s]
+             (let [{:keys [name] :as x} (dispatch-entry marker s hot-reload?)]
+               (assoc acc name x)))
+           {}
+           coll)))
 
 (defn get-fq-classname
   "Returns the fully qualified classname for 'sym'"

--- a/src/temporal/internal/utils.clj
+++ b/src/temporal/internal/utils.clj
@@ -105,11 +105,6 @@
         (assoc entry :fn f)))
     entry))
 
-(defn find-dispatch-fn
-  "Finds any functions named 't' that carry metadata 'marker'"
-  [dispatch-table t]
-  (resolve-dispatch-fn (find-dispatch dispatch-table t)))
-
 (defn- dispatch-entry
   [marker x hot-reload?]
   (let [f (if (var? x) @x x)

--- a/src/temporal/internal/utils.clj
+++ b/src/temporal/internal/utils.clj
@@ -86,12 +86,13 @@
       (throw (ex-info "workflow/activity not found" {:function t}))))
 
 (defn resolve-dispatch-fn
-  "Resolves a dispatch entry to the current function value. If the entry stores a
-  Var, dereferences it at execution time so re-evaluated definitions are picked up."
+  "Resolves a dispatch entry to a function value. If resolve-dispatch already
+  cached a function in the entry, use that value; otherwise dereference the Var
+  at execution time so re-evaluated definitions are picked up."
   [entry]
-  (if-let [v (:var entry)]
-    @v
-    (:fn entry)))
+  (if (contains? entry :fn)
+    (:fn entry)
+    (some-> entry :var deref)))
 
 (defn resolve-dispatch
   "Resolves a dispatch entry, refreshing marker metadata from the current Var value

--- a/src/temporal/internal/workflow.clj
+++ b/src/temporal/internal/workflow.clj
@@ -85,19 +85,23 @@
   (u/get-annotated-name x ::def))
 
 (defn auto-dispatch
-  []
-  (u/get-annotated-fns ::def))
+  ([]
+   (auto-dispatch {}))
+  ([opts]
+   (u/get-annotated-fns ::def opts)))
 
 (defn import-dispatch
-  [syms]
-  (u/import-dispatch ::def syms))
+  ([syms]
+   (import-dispatch syms {}))
+  ([syms opts]
+   (u/import-dispatch ::def syms opts)))
 
 (defn execute
   [ctx dispatch args]
   (let [{:keys [workflow-type workflow-id]} (get-info)]
     (try+
-     (let [d (u/find-dispatch dispatch workflow-type)
-           f (:fn d)
+     (let [d (u/resolve-dispatch ::def (u/find-dispatch dispatch workflow-type))
+           f (u/resolve-dispatch-fn d)
            a (u/->args args)
            _ (log/trace workflow-id "calling" f "with args:" a)
            r (if (-> d :type (= :legacy))

--- a/src/temporal/workflow.clj
+++ b/src/temporal/workflow.clj
@@ -169,17 +169,23 @@ Arguments:
     (if (= (count params*) 2)                               ;; legacy
       (do
         (println (str *file* ":" (:line (meta &form)) " WARN: (defworkflow " name ") with [ctx {:keys [signals args]}] is deprecated.  Use [args] form."))
-        `(def ~name ^{::w/def {:name ~sname :fqn ~fqn :type :legacy}}
-           (fn [ctx# args#]
-             (log/trace (str ~fqn ": ") args#)
-             (let [f# (fn ~params* (do ~@body))]
-               (f# ctx# args#)))))
+        `(def ~name
+           (with-meta
+             (fn [ctx# args#]
+               (log/trace (str ~fqn ": ") args#)
+               (let [f# (fn ~params* (do ~@body))]
+                 (f# ctx# args#)))
+             {::w/def {:name ~sname :fqn ~fqn :type :legacy}
+              ::u/var (var ~name)})))
       (do
-        `(def ~name ^{::w/def {:name ~sname :fqn ~fqn}}
-           (fn [args#]
-             (log/trace (str ~fqn ": ") args#)
-             (let [f# (fn ~params* (do ~@body))]
-               (f# args#))))))))
+        `(def ~name
+           (with-meta
+             (fn [args#]
+               (log/trace (str ~fqn ": ") args#)
+               (let [f# (fn ~params* (do ~@body))]
+                 (f# args#)))
+             {::w/def {:name ~sname :fqn ~fqn}
+              ::u/var (var ~name)}))))))
 
 (defn invoke
   "

--- a/src/temporal/workflow.clj
+++ b/src/temporal/workflow.clj
@@ -14,7 +14,8 @@
   (:import [io.temporal.api.common.v1 WorkflowExecution]
            [io.temporal.workflow ContinueAsNewOptions ContinueAsNewOptions$Builder DynamicQueryHandler DynamicUpdateHandler ExternalWorkflowStub Workflow WorkflowLock]
            [java.util.function Supplier]
-           [java.time Duration]))
+           [java.time Duration])
+  (:refer-clojure :exclude [await]))
 
 (defn get-info
   "Return info about the current workflow"

--- a/test/temporal/test/hot_reload.clj
+++ b/test/temporal/test/hot_reload.clj
@@ -28,14 +28,6 @@
     (format "%.3fx" (double x))
     x))
 
-(defn- report-criterium-comparison
-  [label benches]
-  (report-benchmark
-   label
-   (into {}
-         (map (fn [[k f]] [k (format-ms (criterium-ms f))]))
-         benches)))
-
 (defn- report-criterium-dispatch-loading-comparison
   [label {:keys [static-dispatch hot-reload-dispatch]}]
   (let [static-ms (criterium-ms static-dispatch)

--- a/test/temporal/test/hot_reload.clj
+++ b/test/temporal/test/hot_reload.clj
@@ -107,6 +107,19 @@
       #(is (= :legacy (:type (u/resolve-dispatch ::iw/def entry)))))
     (is (nil? (:type (u/resolve-dispatch ::iw/def (assoc entry :type :legacy)))))))
 
+(deftest workflow-hot-reload-uses-one-var-snapshot-test
+  (let [dispatch (iw/import-dispatch [hot-reload-workflow] {:hot-reload? true})
+        entry (get dispatch "hot-reload-workflow")
+        first-fn (with-meta (fn [_] :first) (meta hot-reload-workflow))
+        second-fn (with-meta (fn [_] :second) (meta hot-reload-workflow))]
+    (with-var-root #'hot-reload-workflow
+      first-fn
+      #(let [resolved-entry (u/resolve-dispatch ::iw/def entry)]
+         (with-var-root #'hot-reload-workflow
+           second-fn
+           (fn []
+             (is (= :first ((u/resolve-dispatch-fn resolved-entry) nil)))))))))
+
 (defn- synthetic-activity-fns
   [n]
   (mapv (fn [i]

--- a/test/temporal/test/hot_reload.clj
+++ b/test/temporal/test/hot_reload.clj
@@ -1,0 +1,221 @@
+(ns temporal.test.hot-reload
+  (:require [clojure.test :refer [deftest is]]
+            [criterium.core :as criterium]
+            [temporal.activity :refer [defactivity]]
+            [temporal.internal.activity :as ia]
+            [temporal.internal.utils :as u]
+            [temporal.internal.workflow :as iw]
+            [temporal.workflow :refer [defworkflow]]))
+
+(defn- report-benchmark
+  [label data]
+  (println (str "\n" label))
+  (doseq [[k v] data]
+    (println " " (name k) "=" v)))
+
+(defn- criterium-ms
+  [f]
+  (let [result (criterium/quick-benchmark* f {})]
+    (* 1000.0 (first (:mean result)))))
+
+(defn- format-ms
+  [x]
+  (format "%.9f" (double x)))
+
+(defn- format-speedup
+  [x]
+  (if (number? x)
+    (format "%.3fx" (double x))
+    x))
+
+(defn- report-criterium-comparison
+  [label benches]
+  (report-benchmark
+   label
+   (into {}
+         (map (fn [[k f]] [k (format-ms (criterium-ms f))]))
+         benches)))
+
+(defn- report-criterium-dispatch-loading-comparison
+  [label {:keys [static-dispatch hot-reload-dispatch]}]
+  (let [static-ms (criterium-ms static-dispatch)
+        hot-ms (criterium-ms hot-reload-dispatch)]
+    (report-benchmark
+     label
+     {:static-dispatch-ms (format-ms static-ms)
+      :hot-reload-dispatch-ms (format-ms hot-ms)
+      :difference-ms (format-ms (- hot-ms static-ms))
+      :hot-reload-vs-static (format-speedup (if (pos? static-ms)
+                                              (/ hot-ms static-ms)
+                                              :infinite))})))
+
+(defn- report-criterium-reload-comparison
+  [label {:keys [old-static-reload hot-reload]}]
+  (let [old-static-ms (criterium-ms old-static-reload)
+        hot-ms (criterium-ms hot-reload)]
+    (report-benchmark
+     label
+     {:old-static-reload-ms (format-ms old-static-ms)
+      :hot-reload-ms (format-ms hot-ms)
+      :saved-ms (format-ms (- old-static-ms hot-ms))
+      :speedup (format-speedup (if (pos? hot-ms)
+                                 (/ old-static-ms hot-ms)
+                                 :infinite))})))
+
+(defn- with-var-root
+  [v new-root f]
+  (let [old-root @v]
+    (try
+      (alter-var-root v (constantly new-root))
+      (f)
+      (finally
+        (alter-var-root v (constantly old-root))))))
+
+(defactivity hot-reload-activity
+  [_ _]
+  :original)
+
+(defworkflow hot-reload-workflow
+  [_]
+  :original)
+
+(deftest activity-hot-reload-dispatch-test
+  (let [static-dispatch (ia/import-dispatch [hot-reload-activity])
+        reload-dispatch (ia/import-dispatch [hot-reload-activity] {:hot-reload? true})
+        static-entry (get static-dispatch "hot-reload-activity")
+        reload-entry (get reload-dispatch "hot-reload-activity")]
+    (is (fn? (:fn static-entry)))
+    (is (var? (:var reload-entry)))
+    (with-var-root #'hot-reload-activity
+      (with-meta (fn [_ _] :reloaded) (meta hot-reload-activity))
+      #(do
+         (is (= :original ((u/resolve-dispatch-fn static-entry) nil nil)))
+         (is (= :reloaded ((u/resolve-dispatch-fn reload-entry) nil nil)))))))
+
+(deftest workflow-hot-reload-refreshes-dispatch-metadata-test
+  (let [dispatch (iw/import-dispatch [hot-reload-workflow] {:hot-reload? true})
+        entry (get dispatch "hot-reload-workflow")
+        legacy-fn (with-meta
+                    (fn [_ _] :legacy)
+                    {::iw/def {:name "hot-reload-workflow"
+                               :fqn "temporal.test.hot_reload.hot_reload_workflow"
+                               :type :legacy}
+                     ::u/var #'hot-reload-workflow})]
+    (is (nil? (:type entry)))
+    (with-var-root #'hot-reload-workflow
+      legacy-fn
+      #(is (= :legacy (:type (u/resolve-dispatch ::iw/def entry)))))
+    (is (nil? (:type (u/resolve-dispatch ::iw/def (assoc entry :type :legacy)))))))
+
+(defn- synthetic-activity-fns
+  [n]
+  (mapv (fn [i]
+          (let [sym (symbol (str "synthetic-hot-reload-activity-" i))
+                v (intern *ns* sym nil)
+                f (with-meta
+                    (fn [_ _] i)
+                    {::ia/def {:name (str sym)
+                               :fqn (str "temporal.test.hot_reload." sym)}
+                     ::u/var v})]
+            (alter-var-root v (constantly f))
+            f))
+        (range n)))
+
+(defn- synthetic-workflow-fns
+  [n]
+  (mapv (fn [i]
+          (let [sym (symbol (str "synthetic-hot-reload-workflow-" i))
+                v (intern *ns* sym nil)
+                f (with-meta
+                    (fn [_] i)
+                    {::iw/def {:name (str sym)
+                               :fqn (str "temporal.test.hot_reload." sym)}
+                     ::u/var v})]
+            (alter-var-root v (constantly f))
+            f))
+        (range n)))
+
+;; Criterium-backed benchmark helpers. These are intentionally plain functions,
+;; not deftests, because Criterium benchmarks are slower and noisy in CI.
+;; Run them manually from a REPL, e.g.:
+;;
+;;   (require 'temporal.test.hot-reload)
+;;   (temporal.test.hot-reload/criterium-activity-reload-comparison)
+;;   (temporal.test.hot-reload/criterium-workflow-reload-comparison)
+;;   (temporal.test.hot-reload/criterium-activity-dispatch-loading-comparison 100000)
+;;   (temporal.test.hot-reload/criterium-workflow-dispatch-loading-comparison 100000)
+
+(defn criterium-activity-reload-comparison
+  "Compares time-to-changed-activity-visible after a Var root change.
+
+  Old static approach: rebuild the dispatch table, then call the changed activity.
+  Hot-reload approach: reuse the existing hot-reload dispatch entry, deref its Var,
+  then call the changed activity. This intentionally excludes full worker/system
+  restart time, so old-static-reload-ms is a lower bound for the old approach."
+  []
+  (let [reload-dispatch (ia/import-dispatch [hot-reload-activity] {:hot-reload? true})
+        reload-entry (get reload-dispatch "hot-reload-activity")
+        reloaded-fn (with-meta (fn [_ _] :reloaded) (meta hot-reload-activity))
+        old-static-reload #(let [d (ia/import-dispatch [hot-reload-activity])]
+                             ((u/resolve-dispatch-fn (get d "hot-reload-activity")) nil nil))
+        hot-reload #((u/resolve-dispatch-fn reload-entry) nil nil)]
+    (with-var-root #'hot-reload-activity
+      reloaded-fn
+      (fn []
+        (assert (= :reloaded (old-static-reload)))
+        (assert (= :reloaded (hot-reload)))
+        (report-criterium-reload-comparison
+         "criterium activity reload comparison"
+         {:old-static-reload old-static-reload
+          :hot-reload hot-reload})))))
+
+(defn criterium-workflow-reload-comparison
+  "Compares time-to-changed-workflow-visible after a Var root change.
+
+  Old static approach: rebuild the dispatch table, then call the changed workflow.
+  Hot-reload approach: reuse the existing hot-reload dispatch entry, refresh current
+  workflow metadata from its Var, then call the changed workflow. This intentionally
+  excludes full worker/system restart time, so old-static-reload-ms is a lower bound
+  for the old approach."
+  []
+  (let [reload-dispatch (iw/import-dispatch [hot-reload-workflow] {:hot-reload? true})
+        reload-entry (get reload-dispatch "hot-reload-workflow")
+        reloaded-fn (with-meta (fn [_] :reloaded) (meta hot-reload-workflow))
+        old-static-reload #(let [d (iw/import-dispatch [hot-reload-workflow])]
+                             ((u/resolve-dispatch-fn (get d "hot-reload-workflow")) nil))
+        hot-reload #((u/resolve-dispatch-fn (u/resolve-dispatch ::iw/def reload-entry)) nil)]
+    (with-var-root #'hot-reload-workflow
+      reloaded-fn
+      (fn []
+        (assert (= :reloaded (old-static-reload)))
+        (assert (= :reloaded (hot-reload)))
+        (report-criterium-reload-comparison
+         "criterium workflow reload comparison"
+         {:old-static-reload old-static-reload
+          :hot-reload hot-reload})))))
+
+(defn criterium-activity-dispatch-loading-comparison
+  ([]
+   (criterium-activity-dispatch-loading-comparison 100000))
+  ([n]
+   (let [activities (synthetic-activity-fns n)]
+     (report-criterium-dispatch-loading-comparison
+      "criterium activity dispatch loading comparison"
+      {:static-dispatch #(ia/import-dispatch activities)
+       :hot-reload-dispatch #(ia/import-dispatch activities {:hot-reload? true})}))))
+
+(defn criterium-workflow-dispatch-loading-comparison
+  ([]
+   (criterium-workflow-dispatch-loading-comparison 100000))
+  ([n]
+   (let [workflows (synthetic-workflow-fns n)]
+     (report-criterium-dispatch-loading-comparison
+      "criterium workflow dispatch loading comparison"
+      {:static-dispatch #(iw/import-dispatch workflows)
+       :hot-reload-dispatch #(iw/import-dispatch workflows {:hot-reload? true})}))))
+
+(comment
+  (criterium-activity-reload-comparison)
+  (criterium-workflow-reload-comparison)
+  (criterium-activity-dispatch-loading-comparison 100000)
+  (criterium-workflow-dispatch-loading-comparison 100000))


### PR DESCRIPTION
Two things that make REPLing a bit nicer

 ### 1. Silences the clojure.core/await warning

```clojure
;; Before — every time you load temporal.workflow:
WARNING: await already refers to: #'clojure.core/await in namespace:
temporal.workflow, being replaced by: #'temporal.workflow/await

;; After — nothing. The core `await` isn't used anyway.
```
The SDK only ever uses its own `temporal.workflow/await`.

 ### 2. Hot reload, this is the real change in this PR

Adds two opt-in flags that store dispatch entries as Vars and deref them at execution time instead:

```clojure
(worker/start client {:task-queue "my-queue"
                      :hot-reload-activities? true  ;; default false
                      :hot-reload-workflows?  true})
 ```

Re-evaluate a defactivity and the running worker picks it up immediately. Workflow hot reload is available too but marked as dev-only since workflow changes can mess with replay determinism.

Also closes https://github.com/manetu/temporal-clojure-sdk/issues/72