### PR TITLE
Add priority and fairness workflow options

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,8 @@
                                     [eftest "0.6.0"]
                                     [mockery "0.1.4"]
                                     [io.temporal/temporal-opentracing "1.36.0"]
-                                    [io.opentracing/opentracing-mock "0.33.0"]]
+                                    [io.opentracing/opentracing-mock "0.33.0"]
+                                    [same/ish "0.1.7"]]
                    :resource-paths ["test/temporal/test/resources"]}}
   :cloverage {:runner :eftest
               :runner-opts {:multithread? false

--- a/src/temporal/common.clj
+++ b/src/temporal/common.clj
@@ -2,7 +2,9 @@
 
 (ns temporal.common
   (:require [temporal.internal.utils :as u])
-  (:import [io.temporal.common RetryOptions RetryOptions$Builder]))
+  (:import [io.temporal.common
+            Priority Priority$Builder
+            RetryOptions RetryOptions$Builder]))
 
 (def retry-options
   "
@@ -23,3 +25,19 @@
 (defn ^:no-doc retry-options->
   ^RetryOptions [params]
   (u/build (RetryOptions/newBuilder (RetryOptions/getDefaultInstance)) retry-options params))
+
+(def priority-options
+  "
+  | Value                     | Description                                                                                             | Type              | Default |
+  | ------------------------- | ------------------------------------------------------------------------------------------------------- | ------------      | ------- |
+  | :priority-key             | An integer from 1 to the server-configured maximum (default 5). Smaller priority key values run sooner. | int               | 3       |
+  | :fairness-key             | An identifier for the fairness balancing mechanism.                                                     | String or keyword |         |
+  | :fairness-weight          | The proportion to use for the round robin fairness balancing mechanism.                                 | float             | 1       |
+"
+  {:priority-key    #(.setPriorityKey ^Priority$Builder %1 %2)
+   :fairness-key    #(.setFairnessKey ^Priority$Builder %1 (u/namify %2))
+   :fairness-weight #(.setFairnessWeight ^Priority$Builder %1 %2)})
+
+(defn ^:no-doc priority-options->
+  ^Priority [params]
+  (u/build (Priority/newBuilder) priority-options params))

--- a/src/temporal/internal/activity.clj
+++ b/src/temporal/internal/activity.clj
@@ -27,7 +27,8 @@
    :start-to-close-timeout    #(.setStartToCloseTimeout ^ActivityOptions$Builder %1 %2)
    :schedule-to-close-timeout #(.setScheduleToCloseTimeout ^ActivityOptions$Builder %1 %2)
    :schedule-to-start-timeout #(.setScheduleToStartTimeout ^ActivityOptions$Builder %1 %2)
-   :task-queue                #(.setTaskQueue ^ActivityOptions$Builder %1 %2)})
+   :task-queue                #(.setTaskQueue ^ActivityOptions$Builder %1 %2)
+   :priority                  #(.setPriority ^ActivityOptions$Builder %1 (common/priority-options-> %2))})
 
 (defn import-invoke-options
   [{:keys [start-to-close-timeout schedule-to-close-timeout] :as params}]

--- a/src/temporal/internal/child_workflow.clj
+++ b/src/temporal/internal/child_workflow.clj
@@ -27,7 +27,8 @@
    :retry-options              #(.setRetryOptions ^ChildWorkflowOptions$Builder %1 (common/retry-options-> %2))
    :cron-schedule              #(.setCronSchedule ^ChildWorkflowOptions$Builder %1 ^String %2)
    :cancellation-type          #(.setCancellationType ^ChildWorkflowOptions$Builder %1 (cancellation-type-> %2))
-   :memo                       #(.setMemo ^ChildWorkflowOptions$Builder %1 %2)})
+   :memo                       #(.setMemo ^ChildWorkflowOptions$Builder %1 %2)
+   :priority                   #(.setPriority ^ChildWorkflowOptions$Builder %1 (common/priority-options-> %2))})
 
 (defn child-workflow-options->
   ^ChildWorkflowOptions [options]

--- a/src/temporal/internal/child_workflow.clj
+++ b/src/temporal/internal/child_workflow.clj
@@ -24,8 +24,8 @@
    :workflow-execution-timeout #(.setWorkflowExecutionTimeout ^ChildWorkflowOptions$Builder %1 %2)
    :workflow-run-timeout       #(.setWorkflowRunTimeout ^ChildWorkflowOptions$Builder %1 %2)
    :workflow-task-timeout      #(.setWorkflowTaskTimeout ^ChildWorkflowOptions$Builder %1 %2)
-   :retry-options              #(.setRetryOptions %1 (common/retry-options-> %2))
-   :cron-schedule              #(.setCronSchedule ^ChildWorkflowOptions$Builder %1 %2)
+   :retry-options              #(.setRetryOptions ^ChildWorkflowOptions$Builder %1 (common/retry-options-> %2))
+   :cron-schedule              #(.setCronSchedule ^ChildWorkflowOptions$Builder %1 ^String %2)
    :cancellation-type          #(.setCancellationType ^ChildWorkflowOptions$Builder %1 (cancellation-type-> %2))
    :memo                       #(.setMemo ^ChildWorkflowOptions$Builder %1 %2)})
 

--- a/src/temporal/internal/workflow.clj
+++ b/src/temporal/internal/workflow.clj
@@ -71,7 +71,8 @@
    :cron-schedule               #(.setCronSchedule ^WorkflowOptions$Builder %1 %2)
    :memo                        #(.setMemo ^WorkflowOptions$Builder %1 %2)
    :search-attributes           #(.setSearchAttributes ^WorkflowOptions$Builder %1 %2)
-   :start-delay                 #(.setStartDelay ^WorkflowOptions$Builder %1 %2)})
+   :start-delay                 #(.setStartDelay ^WorkflowOptions$Builder %1 %2)
+   :priority                    #(.setPriority ^WorkflowOptions$Builder %1 (common/priority-options-> %2))})
 
 (defn ^:no-doc wf-options->
   ^WorkflowOptions [params]

--- a/src/temporal/internal/workflow.clj
+++ b/src/temporal/internal/workflow.clj
@@ -67,7 +67,7 @@
    :workflow-execution-timeout  #(.setWorkflowExecutionTimeout ^WorkflowOptions$Builder %1 %2)
    :workflow-run-timeout        #(.setWorkflowRunTimeout ^WorkflowOptions$Builder %1 %2)
    :workflow-task-timeout       #(.setWorkflowTaskTimeout ^WorkflowOptions$Builder %1 %2)
-   :retry-options               #(.setRetryOptions %1 (common/retry-options-> %2))
+   :retry-options               #(.setRetryOptions ^WorkflowOptions$Builder %1 (common/retry-options-> %2))
    :cron-schedule               #(.setCronSchedule ^WorkflowOptions$Builder %1 %2)
    :memo                        #(.setMemo ^WorkflowOptions$Builder %1 %2)
    :search-attributes           #(.setSearchAttributes ^WorkflowOptions$Builder %1 %2)

--- a/test/temporal/test/types.clj
+++ b/test/temporal/test/types.clj
@@ -2,6 +2,7 @@
 
 (ns temporal.test.types
   (:require [clojure.test :refer :all]
+            [same.core :refer [ish?]]
             [temporal.client.worker :as worker]
             [temporal.client.options :as o]
             [temporal.internal.workflow :as w]
@@ -21,9 +22,15 @@
                              :retry-options {:maximum-attempts 1}
                              :cron-schedule "* * * * *"
                              :memo {"foo" "bar"}
-                             :search-attributes {"foo" "bar"}})]
+                             :search-attributes {"foo" "bar"}
+                             :priority {:priority-key 5
+                                        :fairness-key :premium
+                                        :fairness-weight 3.14}})]
       (is (-> x (.getWorkflowId) (= "foo")))
-      (is (-> x (.getTaskQueue) (= "bar"))))))
+      (is (-> x (.getTaskQueue) (= "bar")))
+      (is (-> x (.getPriority) (.getPriorityKey) (= 5)))
+      (is (-> x (.getPriority) (.getFairnessKey) (= "premium")))
+      (is (ish? (-> x (.getPriority) (.getFairnessWeight)) 3.14)))))
 
 (deftest client-options
   (testing "Verify that our stub options work"
@@ -139,7 +146,10 @@
                    :memo {"foo" "bar"}
                    :workflow-id-reuse-policy :terminate-if-running
                    :parent-close-policy :terminate
-                   :cancellation-type :abandon}
+                   :cancellation-type :abandon
+                   :priority {:priority-key 5
+                              :fairness-key :premium
+                              :fairness-weight 3.14}}
           child-workflow-options (cw/child-workflow-options-> options)]
       (is (some? child-workflow-options))
       (is (= "foo" (-> child-workflow-options .getWorkflowId)))
@@ -155,7 +165,10 @@
       (is (= io.temporal.api.enums.v1.ParentClosePolicy/PARENT_CLOSE_POLICY_TERMINATE
              (-> child-workflow-options .getParentClosePolicy)))
       (is (= io.temporal.workflow.ChildWorkflowCancellationType/ABANDON
-             (-> child-workflow-options .getCancellationType))))))
+             (-> child-workflow-options .getCancellationType)))
+      (is (-> child-workflow-options (.getPriority) (.getPriorityKey) (= 5)))
+      (is (-> child-workflow-options (.getPriority) (.getFairnessKey) (= "premium")))
+      (is (ish? (-> child-workflow-options (.getPriority) (.getFairnessWeight)) 3.14)))))
 
 (deftest api-key-tls-options
   (testing "API key alone auto-enables TLS (Temporal Java SDK 1.33+ behavior)"


### PR DESCRIPTION
also fixes a few reflection warnings.

Docstrings and API usage based on the [Priority Java SDK source code](https://github.com/temporalio/sdk-java/blob/b6b4290373df56ee2116970681c506011a7cc884/temporal-sdk/src/main/java/io/temporal/common/Priority.java) and the [Temporal docs](https://docs.temporal.io/develop/task-queue-priority-fairness#how-to-use-priority).