### PR TITLE
fix: support promesa p/handle, p/hmap, and p/hcat against Temporal pr…

### DIFF
--- a/src/temporal/internal/promise.clj
+++ b/src/temporal/internal/promise.clj
@@ -5,14 +5,25 @@
             [temporal.internal.utils :refer [->Func] :as u])
   (:import [clojure.lang IDeref IBlockingDeref]
            [io.temporal.workflow Promise]
-           [java.util.concurrent CompletableFuture]
-           [java.util.function BiFunction]))
+           [java.time Duration]
+           [java.util.concurrent CompletableFuture CompletionStage TimeUnit]
+           [java.util.function BiFunction Function]))
+
+(declare ->temporal)
 
 (deftype PromiseAdapter [^Promise p]
   IDeref
   (deref [_] (.get p))
   IBlockingDeref
-  (deref [_ ms val] (.get p ms val)))
+  (deref [_ ms val] (.get p ms val))
+  CompletionStage
+  (thenCompose [_ f]
+    (pt/-promise
+     (.thenCompose p (->Func (fn [v] (->temporal (.apply ^Function f v))))))))
+
+(defmethod print-method PromiseAdapter
+  [^PromiseAdapter x ^java.io.Writer w]
+  (.write w (str "#<temporal/PromiseAdapter " (.p x) ">")))
 
 (deftype BiFunctionWrapper [f]
   BiFunction
@@ -117,3 +128,29 @@
 
   PromiseAdapter
   (-promise [p] p))
+
+;; IState/IAwaitable: introspection and blocking-await support, so promesa's
+;; p/pending?, p/resolved?, p/rejected?, p/extract, and p/await!/p/await work
+;; against Temporal-backed promises. NOTE: Promise.getFailure() blocks until
+;; the promise completes, so it is only called after an isCompleted guard
+;; (where it returns immediately). ICancellable is deliberately not
+;; implemented: io.temporal.workflow.Promise has no external-cancel API
+;; (cancellation happens via CancellationScope).
+(extend-protocol pt/IState
+  PromiseAdapter
+  (-extract
+    ([it] (pt/-extract it nil))
+    ([it default]
+     (let [^Promise p (.p it)]
+       (if (.isCompleted p) (or (.getFailure p) (.get p)) default))))
+  (-resolved? [it] (let [^Promise p (.p it)] (and (.isCompleted p) (nil? (.getFailure p)))))
+  (-rejected? [it] (let [^Promise p (.p it)] (and (.isCompleted p) (some? (.getFailure p)))))
+  (-pending? [it] (not (.isCompleted ^Promise (.p it)))))
+
+(extend-protocol pt/IAwaitable
+  PromiseAdapter
+  (-await!
+    ([it] (.get ^Promise (.p it)))
+    ([it duration]
+     (let [ms (if (instance? Duration duration) (inst-ms duration) duration)]
+       (.get ^Promise (.p it) (long ms) TimeUnit/MILLISECONDS)))))

--- a/test/temporal/test/promesa.clj
+++ b/test/temporal/test/promesa.clj
@@ -3,10 +3,12 @@
 (ns temporal.test.promesa
   (:require [clojure.test :refer :all]
             [promesa.core :as p]
+            [slingshot.slingshot :refer [throw+]]
             [taoensso.timbre :as log]
             [temporal.client.core :as c]
             [temporal.workflow :refer [defworkflow]]
             [temporal.activity :refer [defactivity] :as a]
+            [temporal.exceptions :as e]
             [temporal.test.utils :as t]))
 
 (use-fixtures :once t/wrap-service)
@@ -16,31 +18,43 @@
   (log/info "activity:" args)
   (str "Hi, " name))
 
+(defactivity promesa-error-activity
+  [_ctx args]
+  (log/info "error-activity:" args)
+  (throw+ {:type ::error ::e/non-retriable? true}))
+
+(defn- invoke
+  "Invokes the error activity when :throw? is set, otherwise the happy-path activity."
+  [{:keys [throw?] :as args}]
+  (if throw?
+    (a/invoke promesa-error-activity args)
+    (a/invoke promesa-activity args)))
+
 (defworkflow promesa-handle-workflow
   [args]
   (log/info "workflow:" args)
-  @(-> (a/invoke promesa-activity args)
-       (p/handle (fn [v _e] v))))
+  @(-> (invoke args)
+       (p/handle (fn [v e] (if e :threw v)))))
 
 (defworkflow promesa-hmap-workflow
   [args]
   (log/info "workflow:" args)
-  @(->> (a/invoke promesa-activity args)
-        (p/hmap (fn [v _e] v))))
+  @(->> (invoke args)
+        (p/hmap (fn [v e] (if e :threw v)))))
 
 (defworkflow promesa-hcat-workflow
   [args]
   (log/info "workflow:" args)
-  @(->> (a/invoke promesa-activity args)
-        (p/hcat (fn [v _e] (p/resolved v)))))
+  @(->> (invoke args)
+        (p/hcat (fn [v e] (p/resolved (if e :threw v))))))
 
 (defworkflow promesa-introspect-workflow
   [args]
   (log/info "workflow:" args)
-  (let [pr (a/invoke promesa-activity args)
+  (let [pr             (invoke args)
         pending-before (p/pending? pr)
         printable?     (try (some? (pr-str pr)) (catch Throwable _ false))
-        value          (p/await pr)]
+        value          (try (p/await! pr) (catch Throwable _ :threw))]
     {:pending-before pending-before
      :printable?     printable?
      :value          value
@@ -48,33 +62,43 @@
      :rejected?      (p/rejected? pr)
      :pending-after  (p/pending? pr)}))
 
+(defn- run
+  [workflow args]
+  (let [wf (t/create-workflow workflow)]
+    (c/start wf args)
+    @(c/get-result wf)))
+
+(defn- verify-combinator
+  "Runs both the success and error paths through a combinator workflow."
+  [workflow]
+  (is (= "Hi, Bob" (run workflow {:name "Bob"})))
+  (is (= :threw    (run workflow {:name "Bob" :throw? true}))))
+
 (deftest handle-test
-  (testing "Verifies that we can round-trip through p/handle"
-    (let [workflow (t/create-workflow promesa-handle-workflow)]
-      (c/start workflow {:name "Bob"})
-      (is (= @(c/get-result workflow) "Hi, Bob")))))
+  (testing "Verifies that p/handle propagates success values and routes errors"
+    (verify-combinator promesa-handle-workflow)))
 
 (deftest hmap-test
-  (testing "Verifies that we can round-trip through p/hmap"
-    (let [workflow (t/create-workflow promesa-hmap-workflow)]
-      (c/start workflow {:name "Bob"})
-      (is (= @(c/get-result workflow) "Hi, Bob")))))
+  (testing "Verifies that p/hmap propagates success values and routes errors"
+    (verify-combinator promesa-hmap-workflow)))
 
 (deftest hcat-test
-  (testing "Verifies that we can round-trip through p/hcat"
-    (let [workflow (t/create-workflow promesa-hcat-workflow)]
-      (c/start workflow {:name "Bob"})
-      (is (= @(c/get-result workflow) "Hi, Bob")))))
+  (testing "Verifies that p/hcat propagates success values and routes errors"
+    (verify-combinator promesa-hcat-workflow)))
+
+(defn- verify-introspect
+  [args {:keys [value resolved? rejected?]}]
+  (let [r (run promesa-introspect-workflow args)]
+    (is (true? (:pending-before r)))
+    (is (true? (:printable? r)))
+    (is (= value     (:value r)))
+    (is (= resolved? (:resolved? r)))
+    (is (= rejected? (:rejected? r)))
+    (is (false? (:pending-after r)))))
 
 (deftest introspect-test
-  (testing "Verifies that p/pending?, p/resolved?, p/rejected?, p/await, and printing work"
-    (let [workflow (t/create-workflow promesa-introspect-workflow)]
-      (c/start workflow {:name "Bob"})
-      (let [{:keys [pending-before printable? value resolved? rejected? pending-after]}
-            @(c/get-result workflow)]
-        (is (true? pending-before))
-        (is (true? printable?))
-        (is (= "Hi, Bob" value))
-        (is (true? resolved?))
-        (is (false? rejected?))
-        (is (false? pending-after))))))
+  (testing "Verifies that p/pending?, p/resolved?, p/rejected?, p/await!, and printing work on resolved and rejected promises"
+    (verify-introspect {:name "Bob"}
+                       {:value "Hi, Bob" :resolved? true :rejected? false})
+    (verify-introspect {:name "Bob" :throw? true}
+                       {:value :threw :resolved? false :rejected? true})))

--- a/test/temporal/test/promesa.clj
+++ b/test/temporal/test/promesa.clj
@@ -1,0 +1,80 @@
+;; Copyright © Manetu, Inc.  All rights reserved
+
+(ns temporal.test.promesa
+  (:require [clojure.test :refer :all]
+            [promesa.core :as p]
+            [taoensso.timbre :as log]
+            [temporal.client.core :as c]
+            [temporal.workflow :refer [defworkflow]]
+            [temporal.activity :refer [defactivity] :as a]
+            [temporal.test.utils :as t]))
+
+(use-fixtures :once t/wrap-service)
+
+(defactivity promesa-activity
+  [ctx {:keys [name] :as args}]
+  (log/info "activity:" args)
+  (str "Hi, " name))
+
+(defworkflow promesa-handle-workflow
+  [args]
+  (log/info "workflow:" args)
+  @(-> (a/invoke promesa-activity args)
+       (p/handle (fn [v _e] v))))
+
+(defworkflow promesa-hmap-workflow
+  [args]
+  (log/info "workflow:" args)
+  @(->> (a/invoke promesa-activity args)
+        (p/hmap (fn [v _e] v))))
+
+(defworkflow promesa-hcat-workflow
+  [args]
+  (log/info "workflow:" args)
+  @(->> (a/invoke promesa-activity args)
+        (p/hcat (fn [v _e] (p/resolved v)))))
+
+(defworkflow promesa-introspect-workflow
+  [args]
+  (log/info "workflow:" args)
+  (let [pr (a/invoke promesa-activity args)
+        pending-before (p/pending? pr)
+        printable?     (try (some? (pr-str pr)) (catch Throwable _ false))
+        value          (p/await pr)]
+    {:pending-before pending-before
+     :printable?     printable?
+     :value          value
+     :resolved?      (p/resolved? pr)
+     :rejected?      (p/rejected? pr)
+     :pending-after  (p/pending? pr)}))
+
+(deftest handle-test
+  (testing "Verifies that we can round-trip through p/handle"
+    (let [workflow (t/create-workflow promesa-handle-workflow)]
+      (c/start workflow {:name "Bob"})
+      (is (= @(c/get-result workflow) "Hi, Bob")))))
+
+(deftest hmap-test
+  (testing "Verifies that we can round-trip through p/hmap"
+    (let [workflow (t/create-workflow promesa-hmap-workflow)]
+      (c/start workflow {:name "Bob"})
+      (is (= @(c/get-result workflow) "Hi, Bob")))))
+
+(deftest hcat-test
+  (testing "Verifies that we can round-trip through p/hcat"
+    (let [workflow (t/create-workflow promesa-hcat-workflow)]
+      (c/start workflow {:name "Bob"})
+      (is (= @(c/get-result workflow) "Hi, Bob")))))
+
+(deftest introspect-test
+  (testing "Verifies that p/pending?, p/resolved?, p/rejected?, p/await, and printing work"
+    (let [workflow (t/create-workflow promesa-introspect-workflow)]
+      (c/start workflow {:name "Bob"})
+      (let [{:keys [pending-before printable? value resolved? rejected? pending-after]}
+            @(c/get-result workflow)]
+        (is (true? pending-before))
+        (is (true? printable?))
+        (is (= "Hi, Bob" value))
+        (is (true? resolved?))
+        (is (false? rejected?))
+        (is (false? pending-after))))))


### PR DESCRIPTION
…omises

PromiseAdapter now implements CompletionStage.thenCompose, which promesa's p/handle/p/hcat require internally (they cast their -hmap result to CompletionStage). Also extends IState and IAwaitable so p/pending?, p/resolved?, p/rejected?, p/extract, and p/await work, and adds a print-method to avoid throwing when a Temporal-backed promise is printed.