### PR TITLE
fix: eliminate reflective interop and gate CI against regressions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,13 @@ jobs:
 
           ./lein version
           ./lein cljfmt check
+
+          ./lein check 2>&1 | tee reflection.out
+          if grep -q "Reflection warning" reflection.out; then
+            echo "Reflection warnings detected - add type hints to eliminate them"
+            exit 1
+          fi
+
           ./lein cloverage
           ./lein jar
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# Type Hints
+
+`*warn-on-reflection*` is enabled project-wide (`:global-vars` in
+`project.clj`), and CI fails the build on any reflection warning in `src`
+(see `.circleci/config.yml`). Type hints are therefore mandatory wherever
+reflective interop would otherwise occur — but their *placement* follows a
+convention:
+
+- **Hint at the binding site**, not the use/call site: function parameter
+  vectors, `let` bindings, and `def`/var tags. Prefer:
+  ```clojure
+  (defn ->byte-string [^bytes value]
+    (ByteString/copyFrom value))
+  ```
+  over:
+  ```clojure
+  (defn ->byte-string [value]
+    (ByteString/copyFrom ^bytes value))
+  ```
+
+- **Don't re-hint an already-hinted local** at its use site — the tag
+  propagates through the scope, including into `reify`/`fn` closures that
+  close over it.
+
+- **Return-type hints for constructor-style fns:** when a `defn`/`def`
+  reliably returns one concrete type (factories, `*->` builders, `create`
+  fns), tag the return instead of re-hinting the result at every call site:
+  ```clojure
+  (defn create
+    (^TestWorkflowEnvironment []
+     (create {}))
+    (^TestWorkflowEnvironment [options]
+     (TestWorkflowEnvironment/newInstance (test-env-options-> options))))
+  ```
+  The tag propagates to every caller's binding via the var's arglist
+  metadata, so callers need no re-hint. This does *not* help when the value
+  comes back through a keyword lookup (`(:worker replayer)` always types as
+  `Object`) or a `clojure.core` fn (`cast`, `ex-cause`, `vec`) — only hint
+  the return when the interop boundary is our own fn. See
+  `temporal.testing.env/create`, `temporal.testing.replayer/create`,
+  `temporal.converter.payload`, `temporal.internal.utils/namify`.
+
+- **Anonymous fns:** when a hint is needed, prefer `(fn [^T x] ...)` over
+  `#(... ^T % ...)` so the hint lands on a parameter rather than a use-site
+  `%`.
+
+- **Branch-narrowed types:** if a local is only known to be a given type
+  inside one branch of a conditional, introduce an inner `let` binding for
+  the narrowed type in that branch rather than hinting the call:
+  ```clojure
+  (if (instance? Promise e)
+    (let [^Promise p e] (.getFailure p))
+    e)
+  ```
+
+- **Accepted exception — uniform builder-threading maps:** code that
+  threads a single builder through a map of setter fns (e.g.
+  `temporal.client.options`) may hint the builder at the use site
+  (`^Builder %1`) across every entry. Consistency within the map matters
+  more than moving the hint to a per-entry binding.
+
+- **Accepted exception — `extend-protocol`/`extend-type` array params:**
+  a primitive-array type hint (e.g. `^bytes`) on a protocol method's
+  parameter does not resolve overloads inside the method body — the
+  macro's expansion loses the array hint, so a call like
+  `(ByteString/copyFrom value)` stays reflective even though the exact
+  same hint works on a plain `defn`. Hint at the call site instead in
+  these bodies (see `temporal.converter.byte-string`), and leave a
+  comment noting why.
+
+## Reflection: what to trust
+
+`lein check` (with project-wide `*warn-on-reflection*`) is the authoritative
+reflection signal — it's what CI greps for `"Reflection warning"` and fails
+the build on. `lein cloverage` also prints reflection warnings, but many are
+**false positives**: cloverage's coverage instrumentation rewrites every
+top-level form, which strips inline `^Type` hints and breaks the local type
+inference that flows through `doto`/`cond->`/`..`/`let`. The compiler then
+re-emits reflection warnings against synthetic locations. Tell-tale signs of
+a cloverage artifact: a location like `some_file.clj:1:6432` (column far past
+the end of line 1, the `ns` form), or a warning pointing at a `p/then`/
+`extend-protocol` form head rather than an actual interop call. Don't chase
+these by adding call-site hints `lein check` doesn't require — verify against
+`lein check` first.
+
+Also note: `org.clojure/tools.analyzer.jvm` is pinned as a direct dependency
+(rather than left to resolve transitively through `core.async`) because
+`core.async`'s `go` macro compiles blocks through it, and versions before
+1.3.3 have two genuine (upstream, unhinted) reflection sites in their own
+source (`Character/isDigit` in `jvm.clj`/`utils.clj`). Since
+`*warn-on-reflection*` is bound for the whole compile — including on-demand
+compilation of source-only dependency jars — those upstream warnings surface
+in `lein check` too and would trip the CI gate. Don't downgrade this pin
+without re-running `lein check` clean.

--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,7 @@
             [lein-codox "0.10.8"]]
   :dependencies [[org.clojure/clojure "1.12.4"]
                  [org.clojure/core.async "1.7.701"]
+                 [org.clojure/tools.analyzer.jvm "1.3.3"]
                  [io.temporal/temporal-shaded "1.36.0"]
                  [com.jayway.jsonpath/json-path "2.9.0"]
                  [com.taoensso/encore "3.139.0"]
@@ -25,6 +26,7 @@
   :repl-options {:init-ns user}
   :java-source-paths ["src" "resources"]
   :javac-options ["-target" "11" "-source" "11"]
+  :global-vars {*warn-on-reflection* true}
 
   :eastwood {:add-linters [:unused-namespaces]}
   :codox {:metadata {:doc/format :markdown}}

--- a/src/temporal/activity.clj
+++ b/src/temporal/activity.clj
@@ -10,7 +10,7 @@
             [temporal.internal.promise :as ip]
             [temporal.internal.utils :as u])
   (:import [io.temporal.workflow Workflow]
-           [io.temporal.activity Activity]))
+           [io.temporal.activity Activity ActivityCancellationToken]))
 
 (defn heartbeat
   "
@@ -98,7 +98,7 @@ Use the native helper functions below to interact with the token without Java in
         (recur)))))
 ```
 "
-  []
+  ^ActivityCancellationToken []
   (let [ctx (Activity/getExecutionContext)]
     (.getCancellationToken ctx)))
 
@@ -108,7 +108,7 @@ Use the native helper functions below to interact with the token without Java in
 Non-blocking. Use in polling loops together with [[get-cancellation-token]].
 
 See also [[throw-if-cancelled!]] for a throw-on-cancel variant."
-  [token]
+  [^ActivityCancellationToken token]
   (.isCancellationRequested token))
 
 (defn throw-if-cancelled!
@@ -116,7 +116,7 @@ See also [[throw-if-cancelled!]] for a throw-on-cancel variant."
 No-op otherwise. Useful as a lightweight cancellation checkpoint inside loops.
 
 See also [[cancellation-requested?]] for a non-throwing variant."
-  [token]
+  [^ActivityCancellationToken token]
   (.throwIfCancellationRequested token))
 
 (defn cancellation-future
@@ -126,7 +126,7 @@ Useful for waiting on cancellation concurrently without polling. Deref (`@`) wil
 the activity is cancelled. Compose with promesa combinators (e.g. `p/race`) as needed.
 
 See also [[cancellation-requested?]] for a non-blocking state check."
-  [token]
+  [^ActivityCancellationToken token]
   (->> (.getCancellationFuture token)
        ip/->temporal
        pt/-promise))

--- a/src/temporal/client/options.clj
+++ b/src/temporal/client/options.clj
@@ -8,7 +8,8 @@
    [io.temporal.client.schedules ScheduleClientOptions ScheduleClientOptions$Builder ScheduleClientPlugin]
    [io.temporal.common.context ContextPropagator]
    [io.temporal.common.interceptors ActivityClientInterceptor WorkflowClientInterceptorBase]
-   [io.temporal.serviceclient GrpcCompression WorkflowServiceStubs WorkflowServiceStubsOptions WorkflowServiceStubsOptions$Builder WorkflowServiceStubsPlugin]))
+   [io.temporal.serviceclient GrpcCompression WorkflowServiceStubs WorkflowServiceStubsOptions WorkflowServiceStubsOptions$Builder WorkflowServiceStubsPlugin]
+   [java.time Duration]))
 
 (defn assoc-default-data-converter [{:keys [data-converter] :as params}]
   (cond-> params
@@ -102,7 +103,7 @@
    :api-key-fn               #(.addApiKey ^WorkflowServiceStubsOptions$Builder %1 (apikey-auth-fn-> %2))
    :enable-https             #(.setEnableHttps ^WorkflowServiceStubsOptions$Builder %1 %2)
    :target                   #(.setTarget ^WorkflowServiceStubsOptions$Builder %1 %2)
-   :rpc-timeout              #(.setRpcTimeout ^WorkflowServiceStubsOptions$Builder %1 %2)
+   :rpc-timeout              #(.setRpcTimeout ^WorkflowServiceStubsOptions$Builder %1 ^Duration %2)
    :rpc-long-poll-timeout    #(.setRpcLongPollTimeout ^WorkflowServiceStubsOptions$Builder %1 %2)
    :rpc-query-timeout        #(.setRpcQueryTimeout ^WorkflowServiceStubsOptions$Builder %1 %2)
    :backoff-reset-freq       #(.setConnectionBackoffResetFrequency ^WorkflowServiceStubsOptions$Builder %1 %2)

--- a/src/temporal/client/schedule.clj
+++ b/src/temporal/client/schedule.clj
@@ -6,8 +6,6 @@
   (:import [java.time Duration]
            [io.temporal.client.schedules ScheduleClient ScheduleUpdate ScheduleUpdateInput]))
 
-(set! *warn-on-reflection* true)
-
 (defn create-client
   "Creates a `ScheduleClient` instance suitable for interacting with Temporal's Schedules.
 

--- a/src/temporal/client/worker.clj
+++ b/src/temporal/client/worker.clj
@@ -73,10 +73,11 @@ Options for configuring the worker-factory (See [[start]])
     (map? behavior)
     (let [{:keys [type min-pollers max-pollers]} behavior]
       (case type
+        ;; PollerBehaviorAutoscaling is immutable (no setters) - min/max/initial pollers are only
+        ;; configurable via its 3-arg constructor. A `nil` component defaults to the SDK's own
+        ;; built-in default (1/100/5 respectively; see PollerBehaviorAutoscaling's no-arg ctor).
         :autoscaling
-        (cond-> (PollerBehaviorAutoscaling.)
-          min-pollers (.setMinPollers min-pollers)
-          max-pollers (.setMaxPollers max-pollers))
+        (PollerBehaviorAutoscaling. (some-> min-pollers int) (some-> max-pollers int) nil)
         (throw (IllegalArgumentException. (str "Unknown poller behavior type: " type)))))
 
     :else

--- a/src/temporal/codec.clj
+++ b/src/temporal/codec.clj
@@ -26,7 +26,7 @@
   (datafy [d]
     {:metadata (->> (.getMetadataMap d)
                     (into {})
-                    (m/map-vals #(.toByteArray %)))
+                    (m/map-vals (fn [^ByteString bs] (.toByteArray bs))))
      :data     (-> (.getData d)
                    (.toByteArray))}))
 

--- a/src/temporal/converter/byte_string.clj
+++ b/src/temporal/converter/byte_string.clj
@@ -9,8 +9,11 @@
 (extend-protocol ToByteString
   ;; byte/1 - FIXME: this is not supported by lein-cloverage
   (Class/forName "[B")
+  ;; ^bytes on the param (binding site) does not resolve the overload here - extend-protocol's
+  ;; method-table expansion loses the array hint, and copyFrom stays reflective. Hint at the
+  ;; call instead; see CLAUDE.md's extend-protocol exception.
   (->byte-string [value]
-    (ByteString/copyFrom value))
+    (ByteString/copyFrom ^bytes value))
 
   nil
   (->byte-string [_]

--- a/src/temporal/internal/exceptions.clj
+++ b/src/temporal/internal/exceptions.clj
@@ -10,8 +10,9 @@
 (def exception-type (name ::slingshot))
 
 (defn slingshot? [ex]
-  (and (instance? ApplicationFailure (ex-cause ex))
-       (= exception-type (.getType (cast ApplicationFailure (ex-cause ex))))))
+  (let [^ApplicationFailure cause (ex-cause ex)]
+    (and (instance? ApplicationFailure cause)
+         (= exception-type (.getType cause)))))
 
 (defn forward
   [{:keys [message wrapper] {:keys [::e/non-retriable?] :or {non-retriable? false} :as object} :object :as context}]
@@ -37,5 +38,6 @@
         (throw t)))))
 
 (defn recast-stone [ex]
-  (let [stone (->> ex ex-cause (cast ApplicationFailure) (.getDetails) u/->args :object)]
+  (let [^ApplicationFailure af (->> ex ex-cause (cast ApplicationFailure))
+        stone (->> (.getDetails af) u/->args :object)]
     (throw+ stone)))                                        ;; FIXME: Does not preserve the original stack-trace

--- a/src/temporal/internal/promise.clj
+++ b/src/temporal/internal/promise.clj
@@ -36,14 +36,15 @@
   [x] x)
 
 (defmethod ->temporal PromiseAdapter
-  [x] (.p x))
+  [^PromiseAdapter x] (.p x))
 
 (defmethod ->temporal CompletableFuture
   [^CompletableFuture x]
   (reify Promise
     (get [_] (.get x))
     (handle [_ f]
-      (.handle x (->BiFunctionWrapper (fn [v e] (.apply f v e)))))
+      (let [^BiFunction bf (->BiFunctionWrapper (fn [v e] (.apply f v e)))]
+        (.handle x bf)))
     (isCompleted [_] (.isDone x))))
 
 (defmethod ->temporal :default
@@ -89,7 +90,7 @@
      (letfn [(handler [_v e]
                (if e
                  (let [cause (if (instance? Promise e)
-                               (.getFailure e)
+                               (let [^Promise p e] (.getFailure p))
                                e)]
                    (->temporal (f cause)))
                  (.p it)))]

--- a/src/temporal/internal/schedule.clj
+++ b/src/temporal/internal/schedule.clj
@@ -16,8 +16,6 @@
             ScheduleState
             ScheduleState$Builder]))
 
-(set! *warn-on-reflection* true)
-
 (defn overlap-policy->
   [overlap-policy]
   (case overlap-policy

--- a/src/temporal/internal/utils.clj
+++ b/src/temporal/internal/utils.clj
@@ -15,6 +15,9 @@
 
 (def ^Class object-type Object)
 
+;; `builder` is polymorphic across many unrelated Temporal `Builder` classes (they share no
+;; common interface), so `.build` is unavoidably reflective here by design.
+(set! *warn-on-reflection* false)
 (defn build [builder spec params]
   (log/trace "building" builder "with" params)
   (try
@@ -27,6 +30,7 @@
     (.build builder)
     (catch Exception e
       (log/error e))))
+(set! *warn-on-reflection* true)
 
 (defn get-annotation
   "Retrieves metadata annotation 'a' from 'v'"
@@ -145,7 +149,7 @@
   (log/trace "args:" args)
   (.get args (int 0) object-type))
 
-(def namify
+(def ^String namify
   "Converts strings or keywords to strings, preserving fully qualified keywords when applicable"
   (memoize
    (fn [x]

--- a/src/temporal/promise.clj
+++ b/src/temporal/promise.clj
@@ -10,7 +10,7 @@
 (defn- ->array
   ^"[Lio.temporal.workflow.Promise;" [coll]
   {:pre [(every? (partial instance? PromiseAdapter) coll)]}
-  (into-array Promise (map #(.p %) coll)))
+  (into-array Promise (map (fn [^PromiseAdapter p] (.p p)) coll)))
 
 (defn all
   "Returns Promise that becomes completed when all arguments are completed.

--- a/src/temporal/testing/env.clj
+++ b/src/temporal/testing/env.clj
@@ -47,10 +47,10 @@ Arguments:
 | :search-attributes              | Add a map of search attributes to be registered on the Temporal Server | map | |
 
 "
-  ([]
+  (^TestWorkflowEnvironment []
    (create {}))
 
-  ([options]
+  (^TestWorkflowEnvironment [options]
    (TestWorkflowEnvironment/newInstance (test-env-options-> options))))
 
 (defn start
@@ -68,7 +68,7 @@ Arguments:
   (stop env))
 ```
 "
-  [env {:keys [task-queue] :as options}]
+  [^TestWorkflowEnvironment env {:keys [task-queue] :as options}]
   (let [options (dissoc options :task-queue)
         worker (.newWorker env (u/namify task-queue) (worker/worker-options-> options))]
     (worker/init worker options)
@@ -101,5 +101,5 @@ see [[stop]]
 
 (defn get-client
   "Returns a client instance associated with the mock environment created by [[create]]"
-  [env]
+  [^TestWorkflowEnvironment env]
   (.getWorkflowClient env))

--- a/src/temporal/testing/history.clj
+++ b/src/temporal/testing/history.clj
@@ -32,9 +32,9 @@ Arguments:
 
 See also [[from-file]], [[from-resource]], [[fetch]], [[->json]]
 "
-  ([json]
+  ([^String json]
    (WorkflowExecutionHistory/fromJson json))
-  ([json workflow-id]
+  ([^String json ^String workflow-id]
    (WorkflowExecutionHistory/fromJson json workflow-id)))
 
 (defn- ->file

--- a/src/temporal/testing/replayer.clj
+++ b/src/temporal/testing/replayer.clj
@@ -7,7 +7,8 @@
             [temporal.client.worker :as worker]
             [temporal.testing.env :as env])
   (:import [io.temporal.testing WorkflowReplayer TestWorkflowEnvironment ReplayResults ReplayResults$ReplayError]
-           [io.temporal.common WorkflowExecutionHistory]))
+           [io.temporal.common WorkflowExecutionHistory]
+           [io.temporal.worker Worker]))
 
 (extend-protocol p/Datafiable
   ReplayResults
@@ -51,17 +52,17 @@ Arguments:
 
 See also [[replay]], [[replay-all]], [[replay-history]]
 "
-  ([]
+  (^Replayer []
    (create {}))
 
-  ([{:keys [data-converter dispatch]}]
+  (^Replayer [{:keys [data-converter dispatch]}]
    (let [task-queue  (str "replay-" (java.util.UUID/randomUUID))
          env-options (cond-> {}
                        data-converter (assoc :workflow-client-options {:data-converter data-converter}))
          env         (env/create env-options)
-         worker-obj  (.newWorker ^TestWorkflowEnvironment env task-queue (worker/worker-options-> {}))
+         worker-obj  (.newWorker env task-queue (worker/worker-options-> {}))
          _           (worker/init worker-obj {:dispatch dispatch})
-         _           (.start ^TestWorkflowEnvironment env)]
+         _           (.start env)]
      (->Replayer env worker-obj))))
 
 (defn replay
@@ -121,9 +122,10 @@ See also [[replay]], [[replay-history]]
    (replay-all replayer histories {}))
 
   ([replayer histories {:keys [fail-fast?] :or {fail-fast? false}}]
-   (let [hs (vec histories)]
+   (let [^Iterable hs (vec histories)
+         ^Worker worker (:worker replayer)]
      (try
-       (let [results (WorkflowReplayer/replayWorkflowExecutions hs (boolean fail-fast?) (:worker replayer))]
+       (let [results (WorkflowReplayer/replayWorkflowExecutions hs (boolean fail-fast?) worker)]
          (assoc (d/datafy results) :total (count hs)))
        (catch Exception e
          (throw (ex-info "Workflow replay failed: non-determinism detected"

--- a/test/temporal/test/start_delay.clj
+++ b/test/temporal/test/start_delay.clj
@@ -9,8 +9,6 @@
    [java.time Duration Instant]
    [java.time.temporal ChronoUnit TemporalAmount]))
 
-(set! *warn-on-reflection* true)
-
 (use-fixtures :once t/wrap-service)
 
 (defworkflow delay-workflow


### PR DESCRIPTION
*warn-on-reflection* was only enabled in 2 of 34 src files, so most reflection went unnoticed. Enable it project-wide via :global-vars in project.clj and add type hints to clear every warning that surfaced.

One warning uncovered a real bug: poller-behavior-> called setMinPollers/setMaxPollers on PollerBehaviorAutoscaling, but that SDK class is immutable and has no such methods - any :min-pollers/:max-pollers option would throw at runtime. Fixed by using its validating 3-arg constructor instead.

Document a second hint-placement convention: tagging the return of a constructor-style fn (e.g. testing.env/create) so its type propagates to every caller's binding, instead of re-hinting the result at each use site. Apply it to testing.env/create and activity/get-cancellation-token, which also drops the now-redundant use-site hints in testing.replayer/create.

Add a CircleCI step that fails the build on any reflection warning in src, so new reflection can no longer slip in unnoticed.