### PR TITLE
feat: upgrade Temporal Java SDK 1.36.0 → 1.38.0

### DIFF
--- a/doc/activities.md
+++ b/doc/activities.md
@@ -98,6 +98,8 @@ The traditional way to detect activity cancellation is to call [`heartbeat`](htt
 
 Temporal Java SDK 1.36 introduced [`get-cancellation-token`](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.activity#get-cancellation-token), which provides cancellation detection **without** requiring a heartbeat. This is useful for activities that do not otherwise heartbeat.
 
+The underlying Java type backing this token was renamed in Temporal Java SDK 1.38, from `io.temporal.activity.ActivityCancellationToken` to the generic `io.temporal.common.CancellationToken`. This is transparent to callers of this wrapper — [`cancellation-requested?`](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.activity#cancellation-requested?), [`throw-if-cancelled!`](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.activity#throw-if-cancelled!), and [`cancellation-future`](https://cljdoc.org/d/io.github.manetu/temporal-sdk/CURRENT/api/temporal.activity#cancellation-future) are unaffected.
+
 > **Note:** Cancellation delivery via this API requires a recent Temporal server version.
 
 Use the native helper functions to interact with the token without Java interop:

--- a/doc/clients.md
+++ b/doc/clients.md
@@ -52,6 +52,8 @@ If you need to explicitly control TLS behavior:
 
 Since Temporal Java SDK 1.36, **GZIP compression is enabled by default** on all gRPC calls. This is transparent to most users but may make traffic harder to inspect with tools like Wireshark or grpcurl.
 
+Since Temporal Java SDK 1.36.1, if a unary call is rejected by the server because it doesn't support decompression, the client automatically retries that call uncompressed and remembers the method so subsequent calls to it skip compression — other methods keep using gzip. This requires no configuration.
+
 To disable compression (e.g. for debugging or environments where compression adds overhead):
 
 ```clojure

--- a/doc/workers.md
+++ b/doc/workers.md
@@ -91,7 +91,13 @@ Workers and clients support distributed tracing via the `temporal-opentracing` l
 
 When `OpenTracingOptions` is omitted, the interceptors fall back to `GlobalTracer.get()`.  Using the options builder is preferred for testability — pass a `MockTracer` in tests to verify that spans are captured.
 
-As of Temporal Java SDK 1.36, a new `OpenTracingActivityClientInterceptor` is available for tracing standalone activities executed via `ActivityClient`.  This will be wired in when `temporal.client.activity` (standalone activity support) is added to the SDK.
+As of Temporal Java SDK 1.36, a new `OpenTracingActivityClientInterceptor` is available for tracing Standalone Activities executed via `ActivityClient`.  With [[temporal.client.activity]] now available, wire it in the same way as the other interceptors above, via `:interceptors` in the options map passed to [[temporal.client.activity/create-client]]:
+
+```clojure
+(require '[temporal.client.activity :as ca])
+
+(ca/create-client {:interceptors [(OpenTracingActivityClientInterceptor. opts)]})
+```
 
 ## Plugins
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.manetu/temporal-sdk "2.2.2-SNAPSHOT"
+(defproject io.github.manetu/temporal-sdk "2.3.0-SNAPSHOT"
   :description "A Temporal SDK for Clojure"
   :url "https://github.com/manetu/temporal-clojure-sdk"
   :license {:name "Apache License 2.0"
@@ -14,7 +14,7 @@
   :dependencies [[org.clojure/clojure "1.12.4"]
                  [org.clojure/core.async "1.7.701"]
                  [org.clojure/tools.analyzer.jvm "1.3.3"]
-                 [io.temporal/temporal-shaded "1.36.0"]
+                 [io.temporal/temporal-shaded "1.38.0"]
                  [com.jayway.jsonpath/json-path "2.9.0"]
                  [com.taoensso/encore "3.139.0"]
                  [com.taoensso/timbre "6.6.1"]
@@ -35,7 +35,7 @@
                                     [criterium "0.4.6"]
                                     [eftest "0.6.0"]
                                     [mockery "0.1.4"]
-                                    [io.temporal/temporal-opentracing "1.36.0"]
+                                    [io.temporal/temporal-opentracing "1.38.0"]
                                     [io.opentracing/opentracing-mock "0.33.0"]
                                     [same/ish "0.1.7"]]
                    :resource-paths ["test/temporal/test/resources"]}}

--- a/src/temporal/activity.clj
+++ b/src/temporal/activity.clj
@@ -10,7 +10,8 @@
             [temporal.internal.promise :as ip]
             [temporal.internal.utils :as u])
   (:import [io.temporal.workflow Workflow]
-           [io.temporal.activity Activity ActivityCancellationToken]))
+           [io.temporal.activity Activity]
+           [io.temporal.common CancellationToken]))
 
 (defn heartbeat
   "
@@ -75,17 +76,18 @@ When `false` the activity is a Standalone Activity (introduced in Temporal Java 
 
 (defn get-cancellation-token
   "
-Returns an [ActivityCancellationToken](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/activity/ActivityCancellationToken.html)
+Returns a [CancellationToken](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/common/CancellationToken.html)
 that can be used to detect activity cancellation without requiring a heartbeat response. Unlike [[heartbeat]],
 this allows cancellation detection even in activities that do not heartbeat.
 
 **Requires a recent Temporal server version** to deliver cancellation via this path.
-Introduced in Temporal Java SDK 1.36.
+Introduced in Temporal Java SDK 1.36 as `io.temporal.activity.ActivityCancellationToken`; that type was
+removed in 1.38 in favor of the generic `io.temporal.common.CancellationToken`.
 
 Use the native helper functions below to interact with the token without Java interop:
 - [[cancellation-requested?]] — non-blocking boolean check
 - [[throw-if-cancelled!]] — throw if cancelled (convenient for checkpointed loops)
-- [[cancellation-future]] — promesa-compatible promise that completes on cancellation
+- [[cancellation-future]] — promesa-compatible promise that resolves (as a failure) on cancellation
 
 ```clojure
 (defactivity my-activity
@@ -98,7 +100,7 @@ Use the native helper functions below to interact with the token without Java in
         (recur)))))
 ```
 "
-  ^ActivityCancellationToken []
+  ^CancellationToken []
   (let [ctx (Activity/getExecutionContext)]
     (.getCancellationToken ctx)))
 
@@ -108,7 +110,7 @@ Use the native helper functions below to interact with the token without Java in
 Non-blocking. Use in polling loops together with [[get-cancellation-token]].
 
 See also [[throw-if-cancelled!]] for a throw-on-cancel variant."
-  [^ActivityCancellationToken token]
+  [^CancellationToken token]
   (.isCancellationRequested token))
 
 (defn throw-if-cancelled!
@@ -116,17 +118,18 @@ See also [[throw-if-cancelled!]] for a throw-on-cancel variant."
 No-op otherwise. Useful as a lightweight cancellation checkpoint inside loops.
 
 See also [[cancellation-requested?]] for a non-throwing variant."
-  [^ActivityCancellationToken token]
+  [^CancellationToken token]
   (.throwIfCancellationRequested token))
 
 (defn cancellation-future
-  "Returns a promesa-compatible promise that completes (with `nil`) when cancellation is requested.
+  "Returns a promesa-compatible promise that resolves as a failure with `ActivityCanceledException`
+when cancellation is requested. It never resolves successfully.
 
 Useful for waiting on cancellation concurrently without polling. Deref (`@`) will block until
-the activity is cancelled. Compose with promesa combinators (e.g. `p/race`) as needed.
+the activity is cancelled, then throw. Compose with promesa combinators (e.g. `p/race`) as needed.
 
 See also [[cancellation-requested?]] for a non-blocking state check."
-  [^ActivityCancellationToken token]
+  [^CancellationToken token]
   (->> (.getCancellationFuture token)
        ip/->temporal
        pt/-promise))
@@ -152,6 +155,9 @@ Arguments:
 | :start-to-close-timeout    | Maximum time of a single Activity execution attempt.                                       | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | 3 seconds |
 | :schedule-to-close-timeout | Total time that a workflow is willing to wait for Activity to complete.                    | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | |
 | :schedule-to-start-timeout | Time that the Activity Task can stay in the Task Queue before it is picked up by a Worker. | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | |
+| :task-queue                | Task queue to dispatch the activity to, if different from the workflow's.                  | String | same as workflow |
+| :priority                  | Priority/fairness options (see [[temporal.common/priority-options]])                       | map | |
+| :summary                   | Single-line fixed summary shown in UI/CLI (Temporal Markdown)                              | String | |
 
 #### cancellation types
 
@@ -201,6 +207,7 @@ Arguments:
 | :retry-options             | Define how activity is retried in case of failure.                                         | [[temporal.common/retry-options]] | |
 | :do-not-include-args       | When set to true, the serialized arguments of the local Activity are not included in the Marker Event that stores the local Activity's invocation result. | boolean | false |
 | :local-retry-threshold     | Maximum time to retry locally, while keeping the Workflow Task open via a Heartbeat.       | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | |
+| :summary                   | Single-line fixed summary shown in UI/CLI (Temporal Markdown)                              | String | |
 
 ```clojure
 (defactivity my-activity

--- a/src/temporal/client/activity.clj
+++ b/src/temporal/client/activity.clj
@@ -45,6 +45,17 @@
    (let [service (copts/service-stub-> options timeout)]
      (ActivityClient/newInstance service (copts/activity-client-options-> options)))))
 
+(defn- handle->map
+  [^UntypedActivityHandle handle]
+  {:activity-id     (.getActivityId handle)
+   :activity-run-id (.getActivityRunId handle)
+   :result          (-> (.getResultAsync handle u/object-type)
+                        (p/catch e/slingshot? e/recast-stone)
+                        (p/catch (fn [e]
+                                   (log/error e)
+                                   (throw e))))
+   :handle          handle})
+
 (defn start
   "Starts a Standalone Activity asynchronously, returning a handle map immediately.
 
@@ -113,14 +124,7 @@
    (let [act-name (ac/resolve-activity-name activity)
          handle   (ac/start-untyped-handle client act-name options params)]
      (log/trace "start:" act-name "options:" options)
-     {:activity-id     (.getActivityId ^UntypedActivityHandle handle)
-      :activity-run-id (.getActivityRunId ^UntypedActivityHandle handle)
-      :result          (-> (.getResultAsync ^UntypedActivityHandle handle u/object-type)
-                           (p/catch e/slingshot? e/recast-stone)
-                           (p/catch (fn [e]
-                                      (log/error e)
-                                      (throw e))))
-      :handle          handle})))
+     (handle->map handle))))
 
 (defn execute
   "Executes a Standalone Activity synchronously, blocking until it completes.
@@ -147,6 +151,30 @@
          handle   (ac/start-untyped-handle client act-name options params)]
      (log/trace "execute:" act-name "options:" options)
      (.getResult ^UntypedActivityHandle handle u/object-type))))
+
+(defn get-handle
+  "Returns a handle map for a previously-started Standalone Activity, identified by
+  `activity-id` and (optionally) `activity-run-id`.
+
+  Useful for reattaching to an activity started elsewhere — e.g. a different process — or for
+  calling [[cancel]], [[terminate]], or [[describe]] without holding on to the handle map
+  originally returned by [[start]].
+
+  Arguments:
+
+  - `client`: An `ActivityClient` created with [[create-client]]
+  - `activity-id`: The activity ID to reattach to
+  - `activity-run-id`: Optional run ID; when omitted, the client resolves the current run
+
+  ```clojure
+  (let [h (get-handle client \"my-activity-id\")]
+    (describe h))
+  ```
+  "
+  ([client activity-id]
+   (handle->map (ac/get-handle client activity-id)))
+  ([client activity-id activity-run-id]
+   (handle->map (ac/get-handle client activity-id activity-run-id))))
 
 (defn cancel
   "Requests cancellation of a Standalone Activity identified by `handle`.

--- a/src/temporal/client/core.clj
+++ b/src/temporal/client/core.clj
@@ -79,7 +79,10 @@ Arguments:
 | `:cron-schedule`               | Cron expression for scheduled execution                    |
 | `:memo`                        | Arbitrary metadata map                                     |
 | `:search-attributes`           | Indexed attributes for workflow visibility                 |
-| `:start-delay`                 | Delay before starting the workflow (Duration)              |
+| `:start-delay`                 | Delay before starting the workflow (Duration)               |
+| `:priority`                    | Priority/fairness options (see [[temporal.common/priority-options]]) |
+| `:static-summary`              | Single-line fixed summary shown in UI/CLI (Temporal Markdown); cannot be updated after start |
+| `:static-details`              | Multi-line fixed details shown in UI/CLI (Temporal Markdown); cannot be updated after start |
 
 Workflow ID Conflict Policies (`:workflow-id-conflict-policy`):
 

--- a/src/temporal/client/options.clj
+++ b/src/temporal/client/options.clj
@@ -94,7 +94,7 @@
 | :keepalive-timeout        | Set the keep alive timeout                                                  | [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html) | |
 | :keepalive-without-stream | Set if client sends keepalive pings even with no active RPCs                | boolean       | false |
 | :metrics-scope            | The scope to be used for metrics reporting                                  | [Scope](https://github.com/uber-java/tally/blob/master/core/src/main/java/com/uber/m3/tally/Scope.java) | |
-| :grpc-compression         | Sets gRPC transport compression (since Temporal Java SDK 1.36, GZIP is the default). Pass `GrpcCompression/NONE` to disable. | [GrpcCompression](https://javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/serviceclient/GrpcCompression.html) | GZIP |
+| :grpc-compression         | Sets gRPC transport compression (since Temporal Java SDK 1.36, GZIP is the default; since 1.36.1, a call that the server rejects for compression automatically retries uncompressed). Pass `GrpcCompression/NONE` to disable. | [GrpcCompression](https://javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/serviceclient/GrpcCompression.html) | GZIP |
 | :plugins                  | Collection of plugins to customize gRPC stubs behavior (since Temporal Java SDK 1.33).       | [WorkflowServiceStubsPlugin](https://javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/serviceclient/WorkflowServiceStubsPlugin.html) | |
 
 "

--- a/src/temporal/client/worker.clj
+++ b/src/temporal/client/worker.clj
@@ -117,6 +117,8 @@ Options for configuring workers (See [[start]])
 | :activity-task-pollers-behavior                 |           | Configures poller scaling behavior for activity tasks. Use :autoscaling for automatic scaling or a map with {:type :autoscaling :min-pollers n :max-pollers m}.                                                                                 | keyword / map                                                                  |                                                             |
 | :nexus-task-pollers-behavior                    |           | Configures poller scaling behavior for nexus tasks. Use :autoscaling for automatic scaling or a map with {:type :autoscaling :min-pollers n :max-pollers m}.                                                                                    | keyword / map                                                                  |                                                             |
 | :allow-activity-heartbeat-during-shutdown       |           | When true, removes the restriction on activity heartbeats during graceful shutdown. **Trade-off:** enabling this makes `ActivityWorkerShutdownException` undetectable — activities can no longer distinguish normal heartbeat failure from worker shutdown. | boolean | false |
+| :disable-eager-execution                        |           | Disables eager activity execution, where the server piggybacks an activity task directly onto a workflow task completion response instead of a separate poll. | boolean | false |
+| :max-eager-activity-reservations-per-workflow-task |         | Maximum number of activity slots reserved for eager execution when completing a workflow task. Must be positive; use `:disable-eager-execution` to turn eager execution off entirely — setting this to `0` fails at worker start rather than at options-build time. (Temporal Java SDK 1.38+) | int | 3 |
 
 #### dispatch-table
 
@@ -155,7 +157,9 @@ Options for configuring workers (See [[start]])
    :workflow-task-pollers-behavior                   #(.setWorkflowTaskPollersBehavior ^WorkerOptions$Builder %1 (poller-behavior-> %2))
    :activity-task-pollers-behavior                   #(.setActivityTaskPollersBehavior ^WorkerOptions$Builder %1 (poller-behavior-> %2))
    :nexus-task-pollers-behavior                      #(.setNexusTaskPollersBehavior ^WorkerOptions$Builder %1 (poller-behavior-> %2))
-   :allow-activity-heartbeat-during-shutdown         #(.setAllowActivityHeartbeatDuringShutdown ^WorkerOptions$Builder %1 %2)})
+   :allow-activity-heartbeat-during-shutdown         #(.setAllowActivityHeartbeatDuringShutdown ^WorkerOptions$Builder %1 %2)
+   :disable-eager-execution                          #(.setDisableEagerExecution ^WorkerOptions$Builder %1 %2)
+   :max-eager-activity-reservations-per-workflow-task #(.setMaxEagerActivityReservationsPerWorkflowTask ^WorkerOptions$Builder %1 %2)})
 
 (defn ^:no-doc worker-options->
   ^WorkerOptions [params]

--- a/src/temporal/internal/activity.clj
+++ b/src/temporal/internal/activity.clj
@@ -28,7 +28,8 @@
    :schedule-to-close-timeout #(.setScheduleToCloseTimeout ^ActivityOptions$Builder %1 %2)
    :schedule-to-start-timeout #(.setScheduleToStartTimeout ^ActivityOptions$Builder %1 %2)
    :task-queue                #(.setTaskQueue ^ActivityOptions$Builder %1 %2)
-   :priority                  #(.setPriority ^ActivityOptions$Builder %1 (common/priority-options-> %2))})
+   :priority                  #(.setPriority ^ActivityOptions$Builder %1 (common/priority-options-> %2))
+   :summary                   #(.setSummary ^ActivityOptions$Builder %1 %2)})
 
 (defn import-invoke-options
   [{:keys [start-to-close-timeout schedule-to-close-timeout] :as params}]
@@ -50,7 +51,8 @@
    :schedule-to-close-timeout #(.setScheduleToCloseTimeout ^LocalActivityOptions$Builder %1  %2)
    :retry-options             #(.setRetryOptions ^LocalActivityOptions$Builder %1 (local-retry-options-> %2))
    :do-not-include-args       #(.setDoNotIncludeArgumentsIntoMarker ^LocalActivityOptions$Builder %1 %2)
-   :local-retry-threshold     #(.setLocalRetryThreshold ^LocalActivityOptions$Builder %1 %2)})
+   :local-retry-threshold     #(.setLocalRetryThreshold ^LocalActivityOptions$Builder %1 %2)
+   :summary                   #(.setSummary ^LocalActivityOptions$Builder %1 %2)})
 
 (defn local-invoke-options->
   ^LocalActivityOptions [{:keys [retry-options] :or {retry-options {}} :as params}]

--- a/src/temporal/internal/activity_client.clj
+++ b/src/temporal/internal/activity_client.clj
@@ -50,35 +50,19 @@
     (a/get-annotation activity)
     (u/namify activity)))
 
-;; ActivityClient interface exposes only typed overloads.  The implementation
-;; (ActivityClientImpl) additionally provides an untyped
-;; start(String, StartActivityOptions, Object...) method.  We locate it once
-;; per concrete class and cache the Method for subsequent calls.
-(defonce ^:private untyped-start-cache (atom {}))
-
-(defn- find-untyped-start-method
-  [^Class client-class]
-  (or (get @untyped-start-cache client-class)
-      (let [m (->> (.getMethods client-class)
-                   (filter (fn [^java.lang.reflect.Method m]
-                             (let [^"[Ljava.lang.Class;" params (.getParameterTypes m)]
-                               (and (= "start" (.getName m))
-                                    (= 3 (alength params))
-                                    (= String (aget params 0))
-                                    (= StartActivityOptions (aget params 1))))))
-                   first)]
-        (when m (.setAccessible ^java.lang.reflect.Method m true))
-        (swap! untyped-start-cache assoc client-class m)
-        m)))
-
+;; ActivityClient declares the untyped start(String, StartActivityOptions, Object...)
+;; overload directly on the public interface, so no reflection is required to reach it.
 (defn start-untyped-handle
   "Dispatches an activity by name string using ActivityClient's untyped start overload.
   Returns a UntypedActivityHandle."
   ^UntypedActivityHandle [^ActivityClient client ^String activity-name opts args]
-  (let [options (start-activity-options-> opts)
-        m       (find-untyped-start-method (class client))]
-    (when-not m
-      (throw (ex-info "ActivityClient does not expose an untyped start method; requires temporal-shaded >= 1.36.0"
-                      {:client-class (class client)})))
-    (.invoke ^java.lang.reflect.Method m client
-             (into-array Object [activity-name options (into-array Object [args])]))))
+  (let [options (start-activity-options-> opts)]
+    (.start client activity-name options (u/->objarray args))))
+
+(defn get-handle
+  "Returns a handle to a previously-started Standalone Activity, identified by activity-id
+  and (optionally) activity-run-id."
+  (^UntypedActivityHandle [^ActivityClient client ^String activity-id]
+   (.getHandle client activity-id nil))
+  (^UntypedActivityHandle [^ActivityClient client ^String activity-id activity-run-id]
+   (.getHandle client activity-id ^String activity-run-id)))

--- a/src/temporal/internal/child_workflow.clj
+++ b/src/temporal/internal/child_workflow.clj
@@ -28,7 +28,9 @@
    :cron-schedule              #(.setCronSchedule ^ChildWorkflowOptions$Builder %1 ^String %2)
    :cancellation-type          #(.setCancellationType ^ChildWorkflowOptions$Builder %1 (cancellation-type-> %2))
    :memo                       #(.setMemo ^ChildWorkflowOptions$Builder %1 %2)
-   :priority                   #(.setPriority ^ChildWorkflowOptions$Builder %1 (common/priority-options-> %2))})
+   :priority                   #(.setPriority ^ChildWorkflowOptions$Builder %1 (common/priority-options-> %2))
+   :static-summary             #(.setStaticSummary ^ChildWorkflowOptions$Builder %1 %2)
+   :static-details             #(.setStaticDetails ^ChildWorkflowOptions$Builder %1 %2)})
 
 (defn child-workflow-options->
   ^ChildWorkflowOptions [options]

--- a/src/temporal/internal/utils.clj
+++ b/src/temporal/internal/utils.clj
@@ -140,7 +140,7 @@
 
 (defn ->objarray
   "Serializes x to an array of Objects, suitable for many Temporal APIs"
-  [x]
+  ^"[Ljava.lang.Object;" [x]
   (into-array object-type [x]))
 
 (defn ->args

--- a/src/temporal/internal/workflow.clj
+++ b/src/temporal/internal/workflow.clj
@@ -72,7 +72,9 @@
    :memo                        #(.setMemo ^WorkflowOptions$Builder %1 %2)
    :search-attributes           #(.setSearchAttributes ^WorkflowOptions$Builder %1 %2)
    :start-delay                 #(.setStartDelay ^WorkflowOptions$Builder %1 %2)
-   :priority                    #(.setPriority ^WorkflowOptions$Builder %1 (common/priority-options-> %2))})
+   :priority                    #(.setPriority ^WorkflowOptions$Builder %1 (common/priority-options-> %2))
+   :static-summary              #(.setStaticSummary ^WorkflowOptions$Builder %1 %2)
+   :static-details              #(.setStaticDetails ^WorkflowOptions$Builder %1 %2)})
 
 (defn ^:no-doc wf-options->
   ^WorkflowOptions [params]

--- a/src/temporal/workflow.clj
+++ b/src/temporal/workflow.clj
@@ -8,12 +8,13 @@
    [temporal.common :as common]
    [temporal.internal.child-workflow :as cw]
    [temporal.internal.exceptions :as e]
+   [temporal.internal.promise :as ip]
    [temporal.internal.search-attributes :as sa]
    [temporal.internal.utils :as u]
    [temporal.internal.workflow :as w])
   (:import [io.temporal.api.common.v1 WorkflowExecution]
            [io.temporal.common InitialVersioningBehavior]
-           [io.temporal.workflow ContinueAsNewOptions ContinueAsNewOptions$Builder DynamicQueryHandler DynamicUpdateHandler ExternalWorkflowStub Workflow WorkflowLock]
+           [io.temporal.workflow ContinueAsNewOptions ContinueAsNewOptions$Builder DynamicQueryHandler DynamicUpdateHandler ExternalWorkflowStub TimerOptions TimerOptions$Builder Workflow WorkflowLock]
            [java.util.function Supplier]
            [java.time Duration])
   (:refer-clojure :exclude [await]))
@@ -40,6 +41,60 @@
   "Efficiently parks the workflow for 'duration'"
   [^Duration duration]
   (Workflow/sleep duration))
+
+(def ^:no-doc timer-options-spec
+  {:summary #(.setSummary ^TimerOptions$Builder %1 %2)})
+
+(defn ^:no-doc timer-options->
+  ^TimerOptions [options]
+  (u/build (TimerOptions/newBuilder (TimerOptions/getDefaultInstance)) timer-options-spec options))
+
+(defn new-timer
+  "
+Starts a timer for 'duration' and returns a promise that resolves once it fires.
+
+Unlike [[sleep]], this does not block the workflow thread while the timer is pending — compose the
+returned promise with other promises (e.g. [[temporal.promise/race]]) to wait on a timer alongside
+other work.
+
+Arguments:
+
+- `duration`: How long the timer should run, as a [Duration](https://docs.oracle.com/javase/8/docs/api//java/time/Duration.html)
+- `options`: (optional) Options map to customize the timer (see below)
+
+#### options map
+
+| Value     | Description                                                    | Type   | Default |
+| --------- | --------------------------------------------------------------| ------ | ------- |
+| :summary  | Single-line fixed summary shown in UI/CLI (Temporal Markdown) | String | |
+
+```clojure
+(let [timer (new-timer (Duration/ofMinutes 5) {:summary \"cooldown\"})]
+  @timer)
+```
+"
+  ([^Duration duration] (new-timer duration {}))
+  ([^Duration duration options]
+   (ip/->PromiseAdapter (Workflow/newTimer duration (timer-options-> options)))))
+
+(defn set-current-details
+  "
+Sets the current details for this workflow execution, visible in the UI/CLI while the workflow is
+running. Unlike a static summary, this may be updated freely as the workflow progresses.
+
+Introduced in Temporal Java SDK 1.36; stabilized (dropped `@Experimental`) in 1.38.
+
+```clojure
+(set-current-details \"awaiting approval from finance\")
+```
+"
+  [^String details]
+  (Workflow/setCurrentDetails details))
+
+(defn get-current-details
+  "Returns the current details most recently set with [[set-current-details]], or `nil` if unset."
+  []
+  (Workflow/getCurrentDetails))
 
 (def default-version (int Workflow/DEFAULT_VERSION))
 
@@ -214,6 +269,9 @@ Arguments:
 | :cron-schedule              | A cron schedule string                                                                     | String | |
 | :cancellation-type          | In case of a child workflow cancellation it fails with a CanceledFailure                   | See `cancellation types` below | |
 | :memo                       | Specifies additional non-indexed information in result of list workflow                    | String | |
+| :priority                   | Priority/fairness options (see [[temporal.common/priority-options]])                       | map | |
+| :static-summary             | Single-line fixed summary shown in UI/CLI (Temporal Markdown); cannot be updated after start | String | |
+| :static-details             | Multi-line fixed details shown in UI/CLI (Temporal Markdown); cannot be updated after start  | String | |
 
 #### cancellation types
 

--- a/test/temporal/test/cancellation_token_test.clj
+++ b/test/temporal/test/cancellation_token_test.clj
@@ -5,7 +5,8 @@
             [temporal.client.core :as c]
             [temporal.workflow :refer [defworkflow]]
             [temporal.activity :refer [defactivity] :as a]
-            [temporal.test.utils :as t]))
+            [temporal.test.utils :as t])
+  (:import [io.temporal.common CancellationToken]))
 
 (use-fixtures :once t/wrap-service)
 
@@ -13,7 +14,10 @@
   [_ _]
   (let [token (a/get-cancellation-token)]
     {:cancelled?        (a/cancellation-requested? token)
-     :future-present?   (some? (a/cancellation-future token))}))
+     :future-present?   (some? (a/cancellation-future token))
+     ;; Pins the Temporal Java SDK 1.38 migration from the deleted
+     ;; io.temporal.activity.ActivityCancellationToken to this generic type.
+     :token-class?      (instance? CancellationToken token)}))
 
 (defworkflow cancellation-token-workflow
   [_]
@@ -25,4 +29,5 @@
       (c/start workflow {})
       (let [result (-> workflow c/get-result deref)]
         (is (false? (:cancelled? result)))
-        (is (true? (:future-present? result)))))))
+        (is (true? (:future-present? result)))
+        (is (true? (:token-class? result)))))))

--- a/test/temporal/test/continue_as_new_test.clj
+++ b/test/temporal/test/continue_as_new_test.clj
@@ -7,7 +7,8 @@
             [temporal.client.core :as c]
             [temporal.testing.env :as e]
             [temporal.workflow :refer [defworkflow] :as w]
-            [temporal.test.utils :as t]))
+            [temporal.test.utils :as t])
+  (:import [io.temporal.workflow Workflow]))
 
 (use-fixtures :once t/wrap-service)
 
@@ -132,3 +133,29 @@
     (let [workflow (t/create-workflow can-use-ramping-version-workflow)]
       (c/start workflow {:iteration 1})
       (is (= @(c/get-result workflow) {:completed true :iteration 2})))))
+
+;;-----------------------------------------------------------------------------
+;; Memo propagation test (Temporal Java SDK 1.37+)
+;;
+;; A workflow that explicitly sets :memo on continue-as-new could not read it
+;; back on the new run under the in-process test environment, even though it
+;; worked against a real server (the memo carried search attributes and
+;; headers across CAN, but dropped the memo). Temporal Java SDK 1.37 fixed the
+;; test server to match real-server behavior. Note this is unlike
+;; :search-attributes, which carries over automatically when *omitted* (see
+;; the carryover tests above) — :memo must be explicitly set on each
+;; continue-as-new call.
+;;-----------------------------------------------------------------------------
+
+(defworkflow can-memo-carryover-workflow
+  [{:keys [iteration]}]
+  (log/info "can-memo-carryover-workflow: iteration" iteration)
+  (if (= iteration 1)
+    (w/continue-as-new {:iteration 2} {:memo {"note" "carried-over"}})
+    {:completed true :iteration iteration :memo (Workflow/getMemo "note" String)}))
+
+(deftest memo-carryover-test
+  (testing "continue-as-new with an explicit :memo is visible on the new run (Temporal Java SDK 1.37+)"
+    (let [workflow (t/create-workflow can-memo-carryover-workflow)]
+      (c/start workflow {:iteration 1})
+      (is (= @(c/get-result workflow) {:completed true :iteration 2 :memo "carried-over"})))))

--- a/test/temporal/test/current_details_test.clj
+++ b/test/temporal/test/current_details_test.clj
@@ -1,0 +1,21 @@
+;; Copyright © Manetu, Inc.  All rights reserved
+
+(ns temporal.test.current-details-test
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [temporal.client.core :as c]
+            [temporal.workflow :refer [defworkflow] :as w]
+            [temporal.test.utils :as t]))
+
+(use-fixtures :once t/wrap-service)
+
+(defworkflow current-details-workflow
+  [_args]
+  (let [before (w/get-current-details)]
+    (w/set-current-details "in progress")
+    {:before before :after (w/get-current-details)}))
+
+(deftest current-details-test
+  (testing "set-current-details/get-current-details round-trip (Temporal Java SDK 1.36+, stable in 1.38)"
+    (let [wf (c/create-workflow (t/get-client) current-details-workflow {:task-queue t/task-queue})]
+      (c/start wf nil)
+      (is (= @(c/get-result wf) {:before nil :after "in progress"})))))

--- a/test/temporal/test/new_timer_test.clj
+++ b/test/temporal/test/new_timer_test.clj
@@ -1,0 +1,41 @@
+;; Copyright © Manetu, Inc.  All rights reserved
+
+(ns temporal.test.new-timer-test
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [taoensso.timbre :as log]
+            [temporal.client.core :as c]
+            [temporal.workflow :refer [defworkflow] :as w]
+            [temporal.test.utils :as t])
+  (:import [io.temporal.workflow TimerOptions]
+           [java.time Duration]))
+
+(use-fixtures :once t/wrap-service)
+
+(deftest timer-options-test
+  (testing ":summary is set on TimerOptions"
+    (let [^TimerOptions opts (w/timer-options-> {:summary "cooldown"})]
+      (is (= "cooldown" (.getSummary opts))))))
+
+(defworkflow new-timer-workflow
+  [args]
+  (log/info "new-timer-workflow:" args)
+  @(w/new-timer (Duration/ofSeconds 1))
+  :ok)
+
+(defworkflow new-timer-with-options-workflow
+  [args]
+  (log/info "new-timer-with-options-workflow:" args)
+  @(w/new-timer (Duration/ofSeconds 1) {:summary "cooldown"})
+  :ok)
+
+(deftest new-timer-fires-test
+  (testing "new-timer returns a promise that resolves once the timer fires"
+    (let [wf (c/create-workflow (t/get-client) new-timer-workflow {:task-queue t/task-queue})]
+      (c/start wf nil)
+      (is (= @(c/get-result wf) :ok)))))
+
+(deftest new-timer-with-options-fires-test
+  (testing "new-timer accepts a :summary option and still resolves"
+    (let [wf (c/create-workflow (t/get-client) new-timer-with-options-workflow {:task-queue t/task-queue})]
+      (c/start wf nil)
+      (is (= @(c/get-result wf) :ok)))))

--- a/test/temporal/test/signal_with_start_test.clj
+++ b/test/temporal/test/signal_with_start_test.clj
@@ -7,7 +7,8 @@
             [temporal.signals :refer [<!] :as s]
             [temporal.workflow :refer [defworkflow]]
             [temporal.activity :refer [defactivity] :as a]
-            [temporal.test.utils :as t]))
+            [temporal.test.utils :as t])
+  (:import [io.temporal.workflow Workflow]))
 
 (use-fixtures :once t/wrap-service)
 
@@ -30,3 +31,24 @@
     (let [workflow (t/create-workflow signal-greeter-workflow)]
       (c/signal-with-start workflow signal-name {:name "Bob"} {:greeting "Hi"})
       (is (= @(c/get-result workflow) "Hi, Bob")))))
+
+;;-----------------------------------------------------------------------------
+;; Priority propagation test (Temporal Java SDK 1.38+)
+;;
+;; WorkflowOptions.priority was previously dropped by signalWithStart; it now
+;; propagates to the started run, matching plain `start`.
+;;-----------------------------------------------------------------------------
+
+(defworkflow signal-priority-workflow
+  [_args]
+  (let [signals (s/create-signal-chan)]
+    (<! signals signal-name)
+    (-> (Workflow/getInfo) .getPriority .getPriorityKey)))
+
+(deftest priority-propagation-test
+  (testing "Verifies that :priority set at create-workflow propagates through signal-with-start (Temporal Java SDK 1.38+)"
+    (let [workflow (c/create-workflow (t/get-client) signal-priority-workflow
+                                      {:task-queue t/task-queue
+                                       :priority {:priority-key 7}})]
+      (c/signal-with-start workflow signal-name {} {})
+      (is (= @(c/get-result workflow) 7)))))

--- a/test/temporal/test/standalone_activity_test.clj
+++ b/test/temporal/test/standalone_activity_test.clj
@@ -192,21 +192,28 @@
       (is (= "my details" (.getStaticDetails opts))))))
 
 ;;; -----------------------------------------------------------------------
-;;; 3. start-untyped-handle — error path and reflection happy path
+;;; 3. start-untyped-handle / get-handle — dispatch against a real ActivityClient
 ;;; -----------------------------------------------------------------------
+;;; ActivityClient declares the untyped start(String, StartActivityOptions, Object...)
+;;; and getHandle(String, String) overloads directly on the public interface (since
+;;; Temporal Java SDK 1.36), so no reflection is required to reach either.
 
-(deftest test-start-untyped-handle-no-method
-  (testing "throws when the client class lacks the untyped start method"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"does not expose an untyped start method"
-                          (ac/start-untyped-handle :not-a-client "act" {:task-queue "q"} {})))))
+(deftest test-start-untyped-handle-rejects-non-client
+  (testing "throws when passed something other than an ActivityClient"
+    ;; Under a plain (hinted) build this is a ClassCastException from the direct
+    ;; interop call; under cloverage — which strips inline ^Type hints during
+    ;; instrumentation (see CLAUDE.md) — the same call falls back to reflection
+    ;; and throws IllegalArgumentException instead. Assert the common supertype
+    ;; so the test is correct under both.
+    (is (thrown? Exception
+                 (ac/start-untyped-handle :not-a-client "act" {:task-queue "q"} {})))))
 
-(deftest test-start-untyped-handle-method-found
-  (testing "find-untyped-start-method locates the untyped start on a real ActivityClientImpl"
-    ;; TestWorkflowEnvironment exposes a service stub we can use to build
-    ;; a real ActivityClient.  The reflection must find the method and invoke
-    ;; it; the test server does not implement StartActivityExecution, so the
-    ;; gRPC call throws — but the method-finding and invoke paths are covered.
+(deftest test-start-untyped-handle-real-client
+  (testing "start-untyped-handle dispatches to a real ActivityClient"
+    ;; TestWorkflowEnvironment exposes a service stub we can use to build a real
+    ;; ActivityClient. The test server does not implement StartActivityExecution,
+    ;; so the gRPC call throws — but the dispatch path (option building + the
+    ;; direct .start interop call) is covered.
     (let [env    (e/create {})
           stubs  (.getWorkflowServiceStubs (e/get-client env))
           client (ActivityClient/newInstance stubs (copts/activity-client-options-> {}))]
@@ -215,6 +222,43 @@
                      (ac/start-untyped-handle client "act" {:task-queue "q"} {})))
         (finally
           (e/stop env))))))
+
+(deftest test-get-handle-real-client
+  (testing "get-handle constructs a real UntypedActivityHandle without an RPC"
+    ;; Unlike start-untyped-handle, getHandle is purely client-side (it just wraps
+    ;; the given IDs), so this succeeds even against the in-memory test server.
+    (let [env    (e/create {})
+          stubs  (.getWorkflowServiceStubs (e/get-client env))
+          client (ActivityClient/newInstance stubs (copts/activity-client-options-> {}))]
+      (try
+        (let [h1 (ac/get-handle client "act-id")
+              h2 (ac/get-handle client "act-id" "run-id")]
+          (is (= "act-id" (.getActivityId ^UntypedActivityHandle h1)))
+          (is (nil? (.getActivityRunId ^UntypedActivityHandle h1)))
+          (is (= "act-id" (.getActivityId ^UntypedActivityHandle h2)))
+          (is (= "run-id" (.getActivityRunId ^UntypedActivityHandle h2))))
+        (finally
+          (e/stop env))))))
+
+;;; -----------------------------------------------------------------------
+;;; 3b. Public get-handle (temporal.client.activity) — reattach to a handle map
+;;; -----------------------------------------------------------------------
+
+(deftest test-public-get-handle
+  (testing "get-handle returns the same handle-map shape as start, for cancel/terminate/describe"
+    (with-redefs [ac/get-handle (fn [_ act-id & _run-id] (make-mock-handle {:reattached act-id}))]
+      (let [handle (ca/get-handle :mock-client "my-act-id")]
+        (is (= "mock-act-id" (:activity-id handle)))
+        (is (= "mock-run-id" (:activity-run-id handle)))
+        (is (some? (:handle handle)))
+        (is (= {:reattached "my-act-id"} @(:result handle)))))))
+
+(deftest test-public-get-handle-with-run-id
+  (testing "get-handle (3-arg) passes activity-run-id through to the internal helper"
+    (let [captured-args (atom nil)]
+      (with-redefs [ac/get-handle (fn [& args] (reset! captured-args args) (make-mock-handle {}))]
+        (ca/get-handle :mock-client "my-act-id" "my-run-id")
+        (is (= '(:mock-client "my-act-id" "my-run-id") @captured-args))))))
 
 ;;; -----------------------------------------------------------------------
 ;;; 4. Happy path — execute (sync)

--- a/test/temporal/test/types_test.clj
+++ b/test/temporal/test/types_test.clj
@@ -5,6 +5,7 @@
             [same.core :refer [ish?]]
             [temporal.client.worker :as worker]
             [temporal.client.options :as o]
+            [temporal.internal.activity :as a]
             [temporal.internal.workflow :as w]
             [temporal.internal.schedule :as s]
             [temporal.internal.child-workflow :as cw])
@@ -25,12 +26,16 @@
                              :search-attributes {"foo" "bar"}
                              :priority {:priority-key 5
                                         :fairness-key :premium
-                                        :fairness-weight 3.14}})]
+                                        :fairness-weight 3.14}
+                             :static-summary "summary"
+                             :static-details "details"})]
       (is (-> x (.getWorkflowId) (= "foo")))
       (is (-> x (.getTaskQueue) (= "bar")))
       (is (-> x (.getPriority) (.getPriorityKey) (= 5)))
       (is (-> x (.getPriority) (.getFairnessKey) (= "premium")))
-      (is (ish? (-> x (.getPriority) (.getFairnessWeight)) 3.14)))))
+      (is (ish? (-> x (.getPriority) (.getFairnessWeight)) 3.14))
+      (is (= "summary" (-> x (.getStaticSummary))))
+      (is (= "details" (-> x (.getStaticDetails)))))))
 
 (deftest client-options
   (testing "Verify that our stub options work"
@@ -71,8 +76,22 @@
                                       :max-heartbeat-throttle-interval                 (Duration/ofSeconds 10)
                                       :local-activity-worker-only                      false
                                       :max-taskqueue-activities-per-second             1.0
-                                      :max-workers-activities-per-second               1.0})]
-      (is (-> x (.isLocalActivityWorkerOnly) false?)))))
+                                      :max-workers-activities-per-second               1.0
+                                      :disable-eager-execution                         true
+                                      :max-eager-activity-reservations-per-workflow-task 5})]
+      (is (-> x (.isLocalActivityWorkerOnly) false?))
+      (is (-> x (.isEagerExecutionDisabled) true?))
+      (is (= 5 (-> x (.getMaxEagerActivityReservationsPerWorkflowTask)))))))
+
+(deftest activity-options
+  (testing "Verify that our activity options work"
+    (let [x (a/invoke-options-> {:start-to-close-timeout (Duration/ofSeconds 1)
+                                 :summary "summary"})]
+      (is (= "summary" (-> x (.getSummary))))))
+  (testing "Verify that our local activity options work"
+    (let [x (a/local-invoke-options-> {:start-to-close-timeout (Duration/ofSeconds 1)
+                                       :summary "summary"})]
+      (is (= "summary" (-> x (.getSummary)))))))
 
 (deftest schedule-client-options
   (testing "Verify that our stub options work"
@@ -149,7 +168,9 @@
                    :cancellation-type :abandon
                    :priority {:priority-key 5
                               :fairness-key :premium
-                              :fairness-weight 3.14}}
+                              :fairness-weight 3.14}
+                   :static-summary "summary"
+                   :static-details "details"}
           child-workflow-options (cw/child-workflow-options-> options)]
       (is (some? child-workflow-options))
       (is (= "foo" (-> child-workflow-options .getWorkflowId)))
@@ -168,7 +189,9 @@
              (-> child-workflow-options .getCancellationType)))
       (is (-> child-workflow-options (.getPriority) (.getPriorityKey) (= 5)))
       (is (-> child-workflow-options (.getPriority) (.getFairnessKey) (= "premium")))
-      (is (ish? (-> child-workflow-options (.getPriority) (.getFairnessWeight)) 3.14)))))
+      (is (ish? (-> child-workflow-options (.getPriority) (.getFairnessWeight)) 3.14))
+      (is (= "summary" (-> child-workflow-options (.getStaticSummary))))
+      (is (= "details" (-> child-workflow-options (.getStaticDetails)))))))
 
 (deftest api-key-tls-options
   (testing "API key alone auto-enables TLS (Temporal Java SDK 1.33+ behavior)"

--- a/test/temporal/test/vthreads_test.clj
+++ b/test/temporal/test/vthreads_test.clj
@@ -65,4 +65,14 @@
         (let [pthreads (:platform-threads (execute {} {:using-virtual-threads false}))]
           (is (every? #(substring-in-coll? % pthreads)
                       ["Workflow Executor" "Activity Executor"
-                       "Workflow Poller"   "Activity Poller"])))))))
+                       "Workflow Poller"   "Activity Poller"]))))
+
+      (testing "Verifies that :using-virtual-threads-on-workflow-worker alone (Activity worker left unset) turns only the Workflow Executor/Poller virtual (Temporal Java SDK 1.38+)"
+        ;; Prior to Temporal Java SDK 1.38, WorkerOptions.isUsingVirtualThreadsOnWorkflowWorker()
+        ;; returned the *activity* worker's flag (#2957), so setting only this option was silently
+        ;; a no-op: the Workflow Executor/Poller pools stayed on platform threads.
+        (let [pthreads (:platform-threads (execute {} {:using-virtual-threads-on-workflow-worker true}))]
+          (is (not-any? #(substring-in-coll? % pthreads)
+                        ["Workflow Executor" "Workflow Poller"]))
+          (is (every? #(substring-in-coll? % pthreads)
+                      ["Activity Executor" "Activity Poller"])))))))


### PR DESCRIPTION
Bump io.temporal/temporal-shaded and temporal-opentracing to 1.38.0.

Breaking change handled:
- io.temporal.activity.ActivityCancellationToken was deleted upstream after one release; replaced by the generic io.temporal.common.CancellationToken

New APIs exposed:
- WorkerOptions: :disable-eager-execution and :max-eager-activity-reservations-per-workflow-task (1.38)
- WorkflowOptions/ChildWorkflowOptions: :static-summary, :static-details (stabilized, dropped @Experimental, 1.38)
- ActivityOptions/LocalActivityOptions: :summary (stabilized, 1.38)
- temporal.workflow: new-timer, set-current-details, get-current-details
- temporal.client.activity: get-handle, to reattach to a previously started Standalone Activity

Cleanup:
- Removed unnecessary reflection in temporal.internal.activity-client; ActivityClient.start/getHandle have been public interface methods since 1.36.0

Tests added/updated to pin SDK behavior changes verified in this range: signalWithStart now propagates :priority (#2966), the test server now propagates an explicitly-set :memo across continue-as-new (#2943), and :using-virtual-threads-on-workflow-worker now actually takes effect instead of silently reading the activity-worker's flag (#2957).

Verified via lein cljfmt check, lein check (zero reflection warnings), lein cloverage (166 tests, 0 failures, 90.32% coverage), and lein jar.