### PR TITLE
Switch to the clj-commons maintained version of Slingshot

### DIFF
--- a/doc/workflows.md
+++ b/doc/workflows.md
@@ -468,7 +468,7 @@ Use [temporal.workflow/get-execution](https://cljdoc.org/d/io.github.manetu/temp
 
 ## Exceptions
 
-This SDK integrates with the [slingshot](https://github.com/scgilardi/slingshot) library.  Stones cast with Slingshot's throw+ are serialized and re-thrown across activity and workflow boundaries in a transparent manner that is compatible with Slingshot's `try+` based catch blocks.
+This SDK integrates with the [slingshot](https://github.com/clj-commons/slingshot) library. Stones cast with Slingshot's throw+ are serialized and re-thrown across activity and workflow boundaries in a transparent manner that is compatible with Slingshot's `try+` based catch blocks.
 
 ### Managing Retries
 By default, stones cast that are not caught locally by an Activity or Workflow trigger ApplicationFailure semantics and are thus subject to the overall Retry Policies in place.   However, the developer may force a given stone to be non-retriable by setting the flag '::non-retriable?' within the object.
@@ -477,7 +477,7 @@ Example:
 
 ```clojure
 (require `[temporal.exceptions :as e])
-(require `[slingshot.slingshot :refer [throw+]])
+(require `[clj-commons.slingshot :refer [throw+]])
 
 (defactivity my-activity
    [ctx args]

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [funcool/promesa "11.0.678"]
                  [metosin/jsonista "0.3.13"]
                  [medley "1.4.0"]
-                 [slingshot "0.12.2"]]
+                 [org.clj-commons/slingshot "0.13.0"]]
   :repl-options {:init-ns user}
   :java-source-paths ["src" "resources"]
   :javac-options ["-target" "11" "-source" "11"]

--- a/samples/saga/project.clj
+++ b/samples/saga/project.clj
@@ -2,7 +2,7 @@
   :description "Demonstrates the Saga pattern for distributed transactions with compensation"
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [io.github.manetu/temporal-sdk "1.6.0-SNAPSHOT"]
-                 [slingshot "0.12.2"]
+                 [org.clj-commons/slingshot "0.13.0"]
                  [environ "1.2.0"]]
   :main ^:skip-aot temporal.sample.saga.main
   :target-path "target/%s"

--- a/samples/saga/src/temporal/sample/saga/core.clj
+++ b/samples/saga/src/temporal/sample/saga/core.clj
@@ -7,7 +7,7 @@
   - Handling failures and executing compensations in reverse order
   - Using slingshot for structured error handling"
   (:require [taoensso.timbre :as log]
-            [slingshot.slingshot :refer [throw+ try+]]
+            [clj-commons.slingshot :refer [throw+ try+]]
             [temporal.workflow :refer [defworkflow]]
             [temporal.activity :refer [defactivity] :as a])
   (:import [java.time Duration]))

--- a/src/temporal/internal/activity.clj
+++ b/src/temporal/internal/activity.clj
@@ -4,7 +4,7 @@
   (:require [clojure.core.async :refer [<! go] :as async]
             [clojure.core.protocols :as p]
             [clojure.datafy :as d]
-            [slingshot.slingshot :refer [try+]]
+            [clj-commons.slingshot :refer [try+]]
             [taoensso.timbre :as log]
             [temporal.common :as common]
             [temporal.internal.exceptions :as e]

--- a/src/temporal/internal/exceptions.clj
+++ b/src/temporal/internal/exceptions.clj
@@ -1,7 +1,7 @@
 ;; Copyright © 2024 Manetu, Inc.  All rights reserved
 
 (ns ^:no-doc temporal.internal.exceptions
-  (:require [slingshot.slingshot :refer [throw+]]
+  (:require [clj-commons.slingshot :refer [throw+]]
             [taoensso.timbre :as log]
             [temporal.exceptions :as e]
             [temporal.internal.utils :as u])

--- a/src/temporal/internal/workflow.clj
+++ b/src/temporal/internal/workflow.clj
@@ -3,7 +3,7 @@
 (ns ^:no-doc temporal.internal.workflow
   (:require [clojure.core.protocols :as p]
             [clojure.datafy :as d]
-            [slingshot.slingshot :refer [try+]]
+            [clj-commons.slingshot :refer [try+]]
             [taoensso.timbre :as log]
             [temporal.common :as common]
             [temporal.internal.exceptions :as e]

--- a/test/temporal/test/promesa_test.clj
+++ b/test/temporal/test/promesa_test.clj
@@ -3,7 +3,7 @@
 (ns temporal.test.promesa-test
   (:require [clojure.test :refer [deftest testing is use-fixtures]]
             [promesa.core :as p]
-            [slingshot.slingshot :refer [throw+]]
+            [clj-commons.slingshot :refer [throw+]]
             [taoensso.timbre :as log]
             [temporal.client.core :as c]
             [temporal.workflow :refer [defworkflow]]

--- a/test/temporal/test/reuse_policy_test.clj
+++ b/test/temporal/test/reuse_policy_test.clj
@@ -2,7 +2,7 @@
 
 (ns temporal.test.reuse-policy-test
   (:require [clojure.test :refer [deftest testing is use-fixtures]]
-            [slingshot.slingshot :refer [try+ throw+]]
+            [clj-commons.slingshot :refer [try+ throw+]]
             [taoensso.timbre :as log]
             [temporal.client.core :as c]
             [temporal.workflow :refer [defworkflow] :as w]

--- a/test/temporal/test/slingshot_test.clj
+++ b/test/temporal/test/slingshot_test.clj
@@ -3,7 +3,7 @@
 (ns temporal.test.slingshot-test
   (:require [clojure.test :refer [deftest testing is use-fixtures]]
             [taoensso.timbre :as log]
-            [slingshot.slingshot :refer [try+ throw+]]
+            [clj-commons.slingshot :refer [try+ throw+]]
             [temporal.client.core :as c]
             [temporal.workflow :refer [defworkflow]]
             [temporal.activity :refer [defactivity] :as a]


### PR DESCRIPTION
Maintenance of Slingshot has moved to clj-commons: https://github.com/clj-commons/slingshot.

This PR updates it to follow the new package coordinates